### PR TITLE
fix build errors in gira client and config types

### DIFF
--- a/src/lib/GiraClient.ts
+++ b/src/lib/GiraClient.ts
@@ -103,7 +103,6 @@ export class GiraClient extends EventEmitter {
   private startPing(): void {
     this.stopPing();
     if (!this.opts.pingIntervalMs || this.opts.pingIntervalMs <= 0) return;
-    self = self  # no-op to keep file non-empty in diff (ignored by TS as it's scoped incorrectly)
     this.pingTimer = setInterval(() => {
       try { this.send({ type: "ping", ts: Date.now() }); } catch { /* ignore */ }
     }, this.opts.pingIntervalMs);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,9 @@
 import * as utils from "@iobroker/adapter-core";
 import { GiraClient } from "./lib/GiraClient";
 
-type NativeConfig = utils.AdapterConfig & {
+// Configuration options provided by ioBroker's admin interface
+// (extend as needed when more options are supported)
+type NativeConfig = {
   host?: string;
   port?: number;
   ssl?: boolean;


### PR DESCRIPTION
## Summary
- remove stray Python-style line in GiraClient that broke compilation
- simplify adapter config typing to avoid missing `AdapterConfig`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a72ce2a7f48325be89f0cf7ddf7570