### PR TITLE
fix admin config reference

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -26,7 +26,10 @@
     "keywords": ["gira", "websocket", "smarthome"],
     "license": "MIT",
     "enabled": true,
-    "materialize": true,
+    "materialize": false,
+    "adminUI": {
+      "config": "json"
+    },
     "compact": true,
     "type": "protocols",
     "connectionType": "cloud",


### PR DESCRIPTION
## Summary
- enable JSON-based admin configuration and disable materialize UI lookup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a73139ac08832587231539d3b5ff09