### PR TITLE
feat: add query auth option

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -9,6 +9,7 @@
     "authHeader": { "type": "header", "label": "Authentifizierung (optional)" },
     "username": { "type": "text", "attr": "username", "label": "Benutzername" },
     "password": { "type": "password", "attr": "password", "label": "Passwort" },
+    "queryAuth": { "type": "checkbox", "attr": "queryAuth", "label": "Token als Query (?authorization=) nutzen" },
     "settingsHeader": { "type": "header", "label": "Verbindungseinstellungen" },
     "pingIntervalMs": { "type": "number", "attr": "pingIntervalMs", "label": "Ping-Intervall (ms)", "min": 0 },
     "reconnectMinMs": { "type": "number", "attr": "reconnect.minMs", "label": "Reconnect min (ms)", "min": 200 },

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ type NativeConfig = {
   path?: string;
   username?: string;
   password?: string;
+  queryAuth?: boolean;
   pingIntervalMs?: number;
   reconnect?: { minMs?: number; maxMs?: number; factor?: number; jitter?: number };
 };
@@ -34,12 +35,13 @@ class GiraEndpointAdapter extends utils.Adapter {
       const host = String(cfg.host ?? "").trim();
       const port = Number(cfg.port ?? 80);
       const ssl = Boolean(cfg.ssl ?? false);
-      const path = String(cfg.path ?? "/").trim() || "/";
+      const queryAuth = Boolean(cfg.queryAuth ?? false);
+      const path = queryAuth ? "/endpoints/ws" : String(cfg.path ?? "/").trim() || "/";
       const username = String(cfg.username ?? "");
       const password = String(cfg.password ?? "");
       const pingIntervalMs = Number(cfg.pingIntervalMs ?? 30000);
 
-      this.client = new GiraClient({ host, port, ssl, path, username, password, pingIntervalMs });
+      this.client = new GiraClient({ host, port, ssl, path, username, password, pingIntervalMs, queryAuth });
 
       this.client.on("open", () => {
         this.log.info(`Connected to ${ssl ? "wss" : "ws"}://${host}:${port}${path}`);


### PR DESCRIPTION
## Summary
- add optional queryAuth flag for token authentication
- allow admin to choose query token over header auth

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a73af4125483259098d489c87d9d9c