### PR TITLE
feat: add endpoint subscriptions

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -14,6 +14,13 @@
     "reconnectMinMs": { "type": "number", "attr": "reconnect.minMs", "label": "Reconnect min (ms)", "min": 200 },
     "reconnectMaxMs": { "type": "number", "attr": "reconnect.maxMs", "label": "Reconnect max (ms)", "min": 1000 },
     "reconnectFactor": { "type": "number", "attr": "reconnect.factor", "label": "Backoff-Faktor", "min": 1 },
-    "reconnectJitter": { "type": "number", "attr": "reconnect.jitter", "label": "Jitter (0..1)", "min": 0, "max": 1 }
+    "reconnectJitter": { "type": "number", "attr": "reconnect.jitter", "label": "Jitter (0..1)", "min": 0, "max": 1 },
+    "subscriptionHeader": { "type": "header", "label": "Subscription" },
+    "endpointKeys": {
+      "type": "text",
+      "attr": "endpointKeys",
+      "label": "Endpoint-Keys (kommagetrennt)",
+      "placeholder": "key1,key2"
+    }
   }
 }

--- a/io-package.json
+++ b/io-package.json
@@ -48,7 +48,8 @@
       "maxMs": 30000,
       "factor": 1.7,
       "jitter": 0.2
-    }
+    },
+    "endpointKeys": ""
   },
   "encryptedNative": ["password"],
   "objects": [],

--- a/src/lib/GiraClient.ts
+++ b/src/lib/GiraClient.ts
@@ -94,6 +94,14 @@ export class GiraClient extends EventEmitter {
     }
   }
 
+  public subscribe(keys: string[]): void {
+    this.send({ type: "subscribe", param: { keys } });
+  }
+
+  public unsubscribe(keys: string[]): void {
+    this.send({ type: "unsubscribe", param: { keys } });
+  }
+
   public close(): void {
     this.closedByUser = true;
     this.stopPing();


### PR DESCRIPTION
## Summary
- add subscribe/unsubscribe helpers to GiraClient
- load configurable endpoint keys and subscribe on connection
- allow runtime subscribe/unsubscribe via control states

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a73afcae008325bd4fa9ef17664d59