### PR TITLE
Handle payload decoding and map endpoint states

### DIFF
--- a/src/lib/GiraClient.ts
+++ b/src/lib/GiraClient.ts
@@ -69,6 +69,28 @@ export class GiraClient extends EventEmitter {
         try { payload = JSON.parse(text); } catch {
           payload = { raw: text };
         }
+
+        // payload.data.value prüfen und ggf. konvertieren
+        const val = payload?.data?.value;
+        if (val !== undefined) {
+          let v: any = val;
+          if (typeof v === "string") {
+            const num = Number(v);
+            if (!isNaN(num)) {
+              v = num;
+            } else {
+              try {
+                v = Buffer.from(v, "base64").toString("utf8");
+              } catch {
+                // ignorieren, wenn keine gültige Base64
+              }
+            }
+          }
+          if (v === 1 || v === "1") v = true;
+          else if (v === 0 || v === "0") v = false;
+          payload.data.value = v;
+        }
+
         this.emit("event", payload);
       } catch (err) {
         this.emit("error", err);


### PR DESCRIPTION
## Summary
- Decode incoming payload data values, including Base64 strings and boolean 1/0 conversions
- Emit adjusted payloads and store endpoint values directly in adapter states

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a73b01418c8325985414dced7e2892