### PR TITLE
Emit and handle request messages

### DIFF
--- a/src/lib/GiraClient.ts
+++ b/src/lib/GiraClient.ts
@@ -66,10 +66,15 @@ export class GiraClient extends EventEmitter {
         const text = typeof data === "string" ? data : data.toString("utf8");
         // Gira-Event-Format: hier anpassen. Wir nehmen zunächst JSON an.
         let payload: any;
-        try { payload = JSON.parse(text); } catch {
+        try {
+          payload = JSON.parse(text);
+        } catch {
           payload = { raw: text };
         }
         this.emit("event", payload);
+        if (payload && payload.type === "request") {
+          this.emit("request", payload);
+        }
       } catch (err) {
         this.emit("error", err);
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,6 +71,11 @@ class GiraEndpointAdapter extends utils.Adapter {
         }
       });
 
+      this.client.on("request", async (payload: any) => {
+        this.log.debug(`Incoming request: ${JSON.stringify(payload)}`);
+        await this.setStateAsync("info.lastRequest", { val: JSON.stringify(payload), ack: true });
+      });
+
       this.client.connect();
     } catch (e: any) {
       this.log.error(`onReady failed: ${e?.message || e}`);


### PR DESCRIPTION
## Summary
- Emit a dedicated `request` event from `GiraClient` for messages with `payload.type === "request"`
- Log and store incoming request payloads in adapter state `info.lastRequest`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a73b03dee88325a9d6d52b6a7b9e83