### PR TITLE
feat: support proxy and TLS options

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -48,7 +48,11 @@
       "maxMs": 30000,
       "factor": 1.7,
       "jitter": 0.2
-    }
+    },
+    "ca": "",
+    "cert": "",
+    "key": "",
+    "rejectUnauthorized": true
   },
   "encryptedNative": ["password"],
   "objects": [],

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.1.0",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "https-proxy-agent": "^7.0.2"
   },
   "devDependencies": {
     "@types/node": "^20.12.12",

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,10 @@ type NativeConfig = {
   password?: string;
   pingIntervalMs?: number;
   reconnect?: { minMs?: number; maxMs?: number; factor?: number; jitter?: number };
+  ca?: string;
+  cert?: string;
+  key?: string;
+  rejectUnauthorized?: boolean;
 };
 
 class GiraEndpointAdapter extends utils.Adapter {
@@ -39,7 +43,13 @@ class GiraEndpointAdapter extends utils.Adapter {
       const password = String(cfg.password ?? "");
       const pingIntervalMs = Number(cfg.pingIntervalMs ?? 30000);
 
-      this.client = new GiraClient({ host, port, ssl, path, username, password, pingIntervalMs });
+      const ca = cfg.ca ? String(cfg.ca) : undefined;
+      const cert = cfg.cert ? String(cfg.cert) : undefined;
+      const key = cfg.key ? String(cfg.key) : undefined;
+      const rejectUnauthorized = cfg.rejectUnauthorized !== undefined ? Boolean(cfg.rejectUnauthorized) : undefined;
+      const tls = { ca, cert, key, rejectUnauthorized };
+
+      this.client = new GiraClient({ host, port, ssl, path, username, password, pingIntervalMs, tls });
 
       this.client.on("open", () => {
         this.log.info(`Connected to ${ssl ? "wss" : "ws"}://${host}:${port}${path}`);


### PR DESCRIPTION
## Summary
- allow configuring CA/client TLS data and forward to WebSocket
- respect HTTP(S)_PROXY env vars via `https-proxy-agent`
- expose TLS settings in adapter config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module 'https-proxy-agent')*

------
https://chatgpt.com/codex/tasks/task_e_68a73b1132fc83259335e59a294d91ff