### PR TITLE
Fix malformed JSON in package descriptors

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -42,16 +42,18 @@
     "path": "/",
     "username": "",
     "password": "",
+    "queryAuth": false,
     "pingIntervalMs": 30000,
     "reconnect": {
       "minMs": 1000,
       "maxMs": 30000,
       "factor": 1.7,
       "jitter": 0.2
-     "ca": "",
-     "cert": "",
-     "key": "",
-     "rejectUnauthorized": true
+    },
+    "ca": "",
+    "cert": "",
+    "key": "",
+    "rejectUnauthorized": true,
     "endpointKeys": ""
   },
   "encryptedNative": ["password"],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iobroker.gira-endpoint",
   "version": "0.0.1",
-  "description": "ioBroker adapter for Gira endpoint (WS/WSS) – emits events as states, minimal viable replacement for Node-RED gira node",
+  "description": "ioBroker adapter for Gira endpoint (WS/WSS) – emits events as states, minimal viable replacement for Node-RED Gira node",
   "author": "you",
   "license": "MIT",
   "main": "build/main.js",


### PR DESCRIPTION
## Summary
- fix `io-package.json` native section structure and add missing `queryAuth` field
- repair `package.json` description string

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7449b8ae4832593ad79e279d85be9