### PR TITLE
Fix endpoint subscription by instantiating client with full options

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -60,8 +60,18 @@ class GiraEndpointAdapter extends utils.Adapter {
       const rejectUnauthorized = cfg.rejectUnauthorized !== undefined ? Boolean(cfg.rejectUnauthorized) : undefined;
       const tls = { ca, cert, key, rejectUnauthorized };
 
-      this.client = new GiraClient({ host, port, ssl, path, username, password, pingIntervalMs, tls });
-      this.client = new GiraClient({ host, port, ssl, path, username, password, pingIntervalMs, queryAuth })
+      // Instantiate client once with all relevant options
+      this.client = new GiraClient({
+        host,
+        port,
+        ssl,
+        path,
+        username,
+        password,
+        pingIntervalMs,
+        queryAuth,
+        tls,
+      });
 
       this.client.on("open", () => {
         this.log.info(`Connected to ${ssl ? "wss" : "ws"}://${host}:${port}${path}`);


### PR DESCRIPTION
## Summary
- ensure GiraClient receives TLS and query auth options in a single instantiation
- maintain connection listeners and subscribe to initial endpoints on connect

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7557fbfa88325834f9921429991b6