### PR TITLE
feat: subscribe to all when no keys configured

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -81,6 +81,12 @@ class GiraEndpointAdapter extends utils.Adapter {
         .filter((k) => k);
       this.endpointKeys = endpointKeys;
 
+      this.log.info(
+        `Configured endpoint keys: ${
+          this.endpointKeys.length ? this.endpointKeys.join(", ") : "(none)"
+        }`
+      );
+
       // Pre-create configured endpoint states so they appear immediately in ioBroker
       for (const key of this.endpointKeys) {
         const id = this.sanitizeId(key);
@@ -115,7 +121,12 @@ class GiraEndpointAdapter extends utils.Adapter {
       this.client.on("open", () => {
         this.log.info(`Connected to ${ssl ? "wss" : "ws"}://${host}:${port}${path}`);
         this.setState("info.connection", true, true);
-        if (this.endpointKeys.length) this.client!.subscribe(this.endpointKeys);
+        if (this.endpointKeys.length) {
+          this.client!.subscribe(this.endpointKeys);
+        } else {
+          this.log.info("Subscribing to all endpoint events (no keys configured)");
+          this.client!.subscribe([]);
+        }
       });
 
       this.client.on("close", (info: any) => {


### PR DESCRIPTION
## Summary
- log configured endpoint keys during startup
- subscribe to all endpoint events when no keys configured

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'events' or its type declarations)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a7775e755c8325a4d1934b9e92dc81