### PR TITLE
Remove temporary test state

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -65,14 +65,6 @@ class GiraEndpointAdapter extends utils.Adapter {
         await this.setStateAsync("info.connection", { val: false, ack: true });
         this.log.debug("Pre-created info states");
 
-        // Create a simple test object to verify object handling
-        await this.setObjectNotExistsAsync("test", {
-          type: "state",
-          common: { name: "Test", type: "string", role: "state", read: true, write: false },
-          native: {},
-        });
-        await this.setStateAsync("test", { val: "hardcoded", ack: true });
-
         const cfg = this.config as unknown as NativeConfig;
         const host = String(cfg.host ?? "").trim();
         const port = Number(cfg.port ?? 80);


### PR DESCRIPTION
## Summary
- remove leftover hard-coded `test` state from adapter startup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module due to missing dependencies; `npm install` returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a77ea1436483258e7e52939f451279