### PR TITLE
Normalize endpoint keys to uppercase

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -77,7 +77,7 @@ class GiraEndpointAdapter extends utils.Adapter {
       
       const endpointKeys = String(cfg.endpointKeys ?? "")
         .split(/[,;\s]+/)
-        .map((k) => k.trim())
+        .map((k) => k.trim().toUpperCase())
         .filter((k) => k);
       this.endpointKeys = endpointKeys;
 
@@ -232,7 +232,7 @@ class GiraEndpointAdapter extends utils.Adapter {
   }
 
   private sanitizeId(s: string): string {
-    return s.replace(/[^a-z0-9_\-\.]/gi, "_");
+    return s.replace(/[^a-z0-9_\-\.]/gi, "_").toUpperCase();
   }
 
   private async onUnload(callback: () => void): Promise<void> {
@@ -254,7 +254,7 @@ class GiraEndpointAdapter extends utils.Adapter {
     if (key === "subscribe" || key === "unsubscribe") {
       const keys = String(state.val || "")
         .split(/[,;\s]+/)
-        .map((k) => k.trim())
+        .map((k) => k.trim().toUpperCase())
         .filter((k) => k);
       if (!keys.length) return;
       if (key === "subscribe") {


### PR DESCRIPTION
## Summary
- Normalize configured endpoint keys to uppercase and sanitize them for consistent state IDs
- Uppercase keys from control subscribe/unsubscribe commands
- Sanitize IDs to uppercase to avoid duplicate lowercase/uppercase states

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/https-proxy-agent)*
- `npm run build` *(fails: Cannot find module/type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a7878ff8488325a69ce3f46de61a70