### PR TITLE
feat: prefix endpoint keys with CO@

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -78,8 +78,9 @@ class GiraEndpointAdapter extends utils.Adapter {
       
       const endpointKeys = String(cfg.endpointKeys ?? "")
         .split(/[,;\s]+/)
-        .map((k) => k.trim().toUpperCase())
-        .filter((k) => k);
+        .map((k) => k.trim())
+        .filter((k) => k)
+        .map((k) => this.normalizeKey(k));
       this.endpointKeys = endpointKeys;
 
       this.log.info(
@@ -235,6 +236,11 @@ class GiraEndpointAdapter extends utils.Adapter {
     }
   }
 
+  private normalizeKey(k: string): string {
+    k = k.trim().toUpperCase();
+    return k.startsWith("CO@") ? k : `CO@${k}`;
+  }
+
   private sanitizeId(s: string): string {
     return s.replace(/[^a-z0-9@_\-\.]/gi, "_");
     return s.replace(/[^a-z0-9_\-\.]/gi, "_").toUpperCase();
@@ -259,14 +265,14 @@ class GiraEndpointAdapter extends utils.Adapter {
     if (key === "subscribe" || key === "unsubscribe") {
       const keys = String(state.val || "")
         .split(/[,;\s]+/)
-        .map((k) => k.trim().toUpperCase())
-        .filter((k) => k);
+        .map((k) => k.trim())
+        .filter((k) => k)
+        .map((k) => this.normalizeKey(k));
       if (!keys.length) return;
-      const normalized = keys.map((k) => k.toUpperCase());
       if (key === "subscribe") {
-        this.client.subscribe(normalized);
+        this.client.subscribe(keys);
       } else {
-        this.client.unsubscribe(normalized);
+        this.client.unsubscribe(keys);
       }
       this.setState(id, { val: state.val, ack: true });
       return;


### PR DESCRIPTION
## Summary
- ensure endpoint keys are automatically prefixed with `CO@`
- normalize keys from config and runtime subscribe/unsubscribe requests

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/https-proxy-agent)
- `npm run build` (fails: Property 'setObjectNotExistsAsync' does not exist on type 'GiraEndpointAdapter')

------
https://chatgpt.com/codex/tasks/task_e_68a78f874bcc832584dae21bbad91ff5