### PR TITLE
feat: separate keys into dedicated admin tab

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -1,27 +1,39 @@
 {
-  "type": "panel",
+  "type": "tabs",
   "items": {
-    "connectionHeader": { "type": "header", "text": "Gira Endpoint Verbindung", "size": 2 },
-    "host": { "type": "text", "attr": "host", "label": "Host", "placeholder": "192.168.x.y" },
-    "port": { "type": "number", "attr": "port", "label": "Port", "min": 1, "max": 65535 },
-    "ssl": { "type": "checkbox", "attr": "ssl", "label": "TLS (wss://) aktivieren" },
-    "path": { "type": "text", "attr": "path", "label": "Pfad", "placeholder": "/" },
-    "authHeader": { "type": "header", "text": "Authentifizierung (optional)", "size": 2 },
-    "username": { "type": "text", "attr": "username", "label": "Benutzername" },
-    "password": { "type": "password", "attr": "password", "label": "Passwort" },
-    "queryAuth": { "type": "checkbox", "attr": "queryAuth", "label": "Token als Query (?authorization=) nutzen" },
-    "settingsHeader": { "type": "header", "text": "Verbindungseinstellungen", "size": 2 },
-    "pingIntervalMs": { "type": "number", "attr": "pingIntervalMs", "label": "Ping-Intervall (ms)", "min": 0 },
-    "reconnectMinMs": { "type": "number", "attr": "reconnect.minMs", "label": "Reconnect min (ms)", "min": 200 },
-    "reconnectMaxMs": { "type": "number", "attr": "reconnect.maxMs", "label": "Reconnect max (ms)", "min": 1000 },
-    "reconnectFactor": { "type": "number", "attr": "reconnect.factor", "label": "Backoff-Faktor", "min": 1 },
-    "reconnectJitter": { "type": "number", "attr": "reconnect.jitter", "label": "Jitter (0..1)", "min": 0, "max": 1 },
-    "subscriptionHeader": { "type": "header", "text": "Subscription", "size": 2 },
-    "endpointKeys": {
-      "type": "text",
-      "attr": "endpointKeys",
-      "label": "Endpoint-Keys (kommagetrennt)",
-      "placeholder": "key1,key2"
+    "settingsTab": {
+      "type": "panel",
+      "label": "Einstellungen",
+      "items": {
+        "connectionHeader": { "type": "header", "text": "Gira Endpoint Verbindung", "size": 2 },
+        "host": { "type": "text", "attr": "host", "label": "Host", "placeholder": "192.168.x.y" },
+        "port": { "type": "number", "attr": "port", "label": "Port", "min": 1, "max": 65535 },
+        "ssl": { "type": "checkbox", "attr": "ssl", "label": "TLS (wss://) aktivieren" },
+        "path": { "type": "text", "attr": "path", "label": "Pfad", "placeholder": "/" },
+        "authHeader": { "type": "header", "text": "Authentifizierung (optional)", "size": 2 },
+        "username": { "type": "text", "attr": "username", "label": "Benutzername" },
+        "password": { "type": "password", "attr": "password", "label": "Passwort" },
+        "queryAuth": { "type": "checkbox", "attr": "queryAuth", "label": "Token als Query (?authorization=) nutzen" },
+        "settingsHeader": { "type": "header", "text": "Verbindungseinstellungen", "size": 2 },
+        "pingIntervalMs": { "type": "number", "attr": "pingIntervalMs", "label": "Ping-Intervall (ms)", "min": 0 },
+        "reconnectMinMs": { "type": "number", "attr": "reconnect.minMs", "label": "Reconnect min (ms)", "min": 200 },
+        "reconnectMaxMs": { "type": "number", "attr": "reconnect.maxMs", "label": "Reconnect max (ms)", "min": 1000 },
+        "reconnectFactor": { "type": "number", "attr": "reconnect.factor", "label": "Backoff-Faktor", "min": 1 },
+        "reconnectJitter": { "type": "number", "attr": "reconnect.jitter", "label": "Jitter (0..1)", "min": 0, "max": 1 }
+      }
+    },
+    "keysTab": {
+      "type": "panel",
+      "label": "Keys",
+      "items": {
+        "subscriptionHeader": { "type": "header", "text": "Subscription", "size": 2 },
+        "endpointKeys": {
+          "type": "array",
+          "attr": "endpointKeys",
+          "label": "Endpoint-Keys",
+          "items": { "type": "text", "label": "Key" }
+        }
+      }
     }
   }
 }

--- a/io-package.json
+++ b/io-package.json
@@ -54,7 +54,7 @@
     "cert": "",
     "key": "",
     "rejectUnauthorized": true,
-    "endpointKeys": ""
+    "endpointKeys": []
   },
   "encryptedNative": ["password"],
   "objects": [],

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ type NativeConfig = {
   cert?: string;
   key?: string;
   rejectUnauthorized?: boolean;
-  endpointKeys?: string;
+  endpointKeys?: string[] | string;
 };
 
 class GiraEndpointAdapter extends utils.Adapter {
@@ -82,11 +82,17 @@ class GiraEndpointAdapter extends utils.Adapter {
       const password = String(cfg.password ?? "");
       const pingIntervalMs = Number(cfg.pingIntervalMs ?? 30000);
       
-      const endpointKeys = String(cfg.endpointKeys ?? "")
-        .split(/[,;\s]+/)
-        .map((k) => k.trim())
-        .filter((k) => k)
-        .map((k) => this.normalizeKey(k));
+      const rawKeys = cfg.endpointKeys;
+      const endpointKeys = Array.isArray(rawKeys)
+        ? rawKeys
+            .map((k) => String(k).trim())
+            .filter((k) => k)
+            .map((k) => this.normalizeKey(k))
+        : String(rawKeys ?? "")
+            .split(/[,;\s]+/)
+            .map((k) => k.trim())
+            .filter((k) => k)
+            .map((k) => this.normalizeKey(k));
       this.endpointKeys = endpointKeys;
 
       this.log.info(


### PR DESCRIPTION
## Summary
- split admin UI into tabs for settings and keys
- show endpoint keys as dynamic list
- accept array of endpoint keys in config

## Testing
- `npm test` (fails: Missing script)
- `npm install` (fails: 403 Forbidden)
- `npm run build` (fails: Cannot find module 'events' and others)

------
https://chatgpt.com/codex/tasks/task_e_68a7a1d85a088325b61fd57e210f281f