### PR TITLE
fix duplicated endpointKeys definition

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,8 +19,6 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
   rejectUnauthorized?: boolean;
   endpointKeys?: string[] | { key: string }[] | string;
 }
-  endpointKeys?: string[] | string;
-};
 
 class GiraEndpointAdapter extends utils.Adapter {
   private client?: GiraClient;


### PR DESCRIPTION
## Summary
- remove leftover duplicate endpointKeys line in AdapterConfig to restore TypeScript parsing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'events', etc. after npm ci 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a724d3c08325aabed5db6da21d03