### PR TITLE
fix: correct admin jsonConfig

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -28,23 +28,12 @@
       "items": {
         "subscriptionHeader": { "type": "header", "text": "Subscription", "size": 2 },
         "endpointKeys": {
-          "type": "array",
-          "attr": "endpointKeys",
-          "label": "Endpoint-Keys",
-          "items": {
-            "type": "text",
-            "label": "Key"
-          }
           "type": "table",
           "attr": "endpointKeys",
           "label": "Endpoint-Keys",
           "items": [
             { "type": "text", "attr": "key", "label": "Key" }
           ]
-          "type": "array",
-          "attr": "endpointKeys",
-          "label": "Endpoint-Keys",
-          "items": { "type": "text", "label": "Key" }
         }
       }
     }


### PR DESCRIPTION
## Summary
- fix malformed admin jsonConfig so adapter config loads

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'events' or its corresponding type declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a83850e48325ac1a207bf82e0517