### PR TITLE
fix: update jsonConfig to new schema

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -6,20 +6,26 @@
       "label": "Einstellungen",
       "items": {
         "connectionHeader": { "type": "header", "text": "Gira Endpoint Verbindung", "size": 2 },
-        "host": { "type": "text", "attr": "host", "label": "Host", "placeholder": "192.168.x.y" },
-        "port": { "type": "number", "attr": "port", "label": "Port", "min": 1, "max": 65535 },
-        "ssl": { "type": "checkbox", "attr": "ssl", "label": "TLS (wss://) aktivieren" },
-        "path": { "type": "text", "attr": "path", "label": "Pfad", "placeholder": "/" },
+        "host": { "type": "text", "label": "Host", "placeholder": "192.168.x.y" },
+        "port": { "type": "number", "label": "Port", "min": 1, "max": 65535 },
+        "ssl": { "type": "checkbox", "label": "TLS (wss://) aktivieren" },
+        "path": { "type": "text", "label": "Pfad", "placeholder": "/" },
         "authHeader": { "type": "header", "text": "Authentifizierung (optional)", "size": 2 },
-        "username": { "type": "text", "attr": "username", "label": "Benutzername" },
-        "password": { "type": "password", "attr": "password", "label": "Passwort" },
-        "queryAuth": { "type": "checkbox", "attr": "queryAuth", "label": "Token als Query (?authorization=) nutzen" },
+        "username": { "type": "text", "label": "Benutzername" },
+        "password": { "type": "password", "label": "Passwort" },
+        "queryAuth": { "type": "checkbox", "label": "Token als Query (?authorization=) nutzen" },
         "settingsHeader": { "type": "header", "text": "Verbindungseinstellungen", "size": 2 },
-        "pingIntervalMs": { "type": "number", "attr": "pingIntervalMs", "label": "Ping-Intervall (ms)", "min": 0 },
-        "reconnectMinMs": { "type": "number", "attr": "reconnect.minMs", "label": "Reconnect min (ms)", "min": 200 },
-        "reconnectMaxMs": { "type": "number", "attr": "reconnect.maxMs", "label": "Reconnect max (ms)", "min": 1000 },
-        "reconnectFactor": { "type": "number", "attr": "reconnect.factor", "label": "Backoff-Faktor", "min": 1 },
-        "reconnectJitter": { "type": "number", "attr": "reconnect.jitter", "label": "Jitter (0..1)", "min": 0, "max": 1 }
+        "pingIntervalMs": { "type": "number", "label": "Ping-Intervall (ms)", "min": 0 },
+        "reconnect": {
+          "type": "panel",
+          "label": "Reconnect",
+          "items": {
+            "minMs": { "type": "number", "label": "Reconnect min (ms)", "min": 200 },
+            "maxMs": { "type": "number", "label": "Reconnect max (ms)", "min": 1000 },
+            "factor": { "type": "number", "label": "Backoff-Faktor", "min": 1 },
+            "jitter": { "type": "number", "label": "Jitter (0..1)", "min": 0, "max": 1 }
+          }
+        }
       }
     },
     "keysTab": {
@@ -29,7 +35,6 @@
         "subscriptionHeader": { "type": "header", "text": "Subscription", "size": 2 },
         "endpointKeys": {
           "type": "table",
-          "attr": "endpointKeys",
           "label": "Endpoint-Keys",
           "items": [
             { "type": "text", "attr": "key", "label": "Key" }


### PR DESCRIPTION
## Summary
- remove deprecated `attr` properties and group reconnect settings in jsonConfig

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module 'events' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a7aa2ec0cc8325a48feba41e5657a5