### PR TITLE
Simplify admin auth and add key descriptions

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -9,11 +9,10 @@
         "host": { "type": "text", "label": "Host", "placeholder": "192.168.x.y" },
         "port": { "type": "number", "label": "Port", "min": 1, "max": 65535 },
         "ssl": { "type": "checkbox", "label": "TLS (wss://) aktivieren" },
-        "path": { "type": "text", "label": "Pfad", "placeholder": "/" },
-        "authHeader": { "type": "header", "text": "Authentifizierung (optional)", "size": 2 },
+        "path": { "type": "text", "label": "Pfad", "default": "/endpoints/ws", "placeholder": "/" },
+        "authHeader": { "type": "header", "text": "Authentifizierung", "size": 2 },
         "username": { "type": "text", "label": "Benutzername" },
         "password": { "type": "password", "label": "Passwort" },
-        "queryAuth": { "type": "checkbox", "label": "Token als Query (?authorization=) nutzen" },
         "settingsHeader": { "type": "header", "text": "Verbindungseinstellungen", "size": 2 },
         "pingIntervalMs": { "type": "number", "label": "Ping-Intervall (ms)", "min": 0 },
         "reconnect": {
@@ -37,7 +36,8 @@
           "type": "table",
           "label": "Endpoint-Keys",
           "items": [
-            { "type": "text", "attr": "key", "label": "Key" }
+            { "type": "text", "attr": "key", "label": "CO@" },
+            { "type": "text", "attr": "name", "label": "Beschreibung" }
           ]
         }
       }

--- a/io-package.json
+++ b/io-package.json
@@ -39,10 +39,9 @@
     "host": "127.0.0.1",
     "port": 80,
     "ssl": false,
-    "path": "/",
+    "path": "/endpoints/ws",
     "username": "",
     "password": "",
-    "queryAuth": false,
     "pingIntervalMs": 30000,
     "reconnect": {
       "minMs": 1000,

--- a/src/lib/GiraClient.ts
+++ b/src/lib/GiraClient.ts
@@ -11,7 +11,6 @@ export interface GiraClientOptions {
   path: string;
   username?: string;
   password?: string;
-  queryAuth?: boolean;
   pingIntervalMs?: number;
   reconnect?: {
     minMs: number; maxMs: number; factor: number; jitter: number;
@@ -41,7 +40,6 @@ export class GiraClient extends EventEmitter {
       path: "/",
       username: "",
       password: "",
-      queryAuth: false,
       pingIntervalMs: 30000,
       reconnect: { minMs: 1000, maxMs: 30000, factor: 1.7, jitter: 0.2 },
       tls: {},
@@ -56,14 +54,8 @@ export class GiraClient extends EventEmitter {
 
     const headers: Record<string, string> = {};
     const token = Buffer.from(`${this.opts.username ?? ""}:${this.opts.password ?? ""}`).toString("base64");
-
-    const path = this.opts.queryAuth
-      ? "/endpoints/ws"
-      : this.opts.path.startsWith("/") ? this.opts.path : `/${this.opts.path}`;
-    const query = this.opts.queryAuth && this.opts.username ? `?authorization=${token}` : "";
-    if (!this.opts.queryAuth && this.opts.username) {
-      headers["Authorization"] = `Basic ${token}`;
-    }
+    const path = this.opts.path.startsWith("/") ? this.opts.path : `/${this.opts.path}`;
+    const query = this.opts.username ? `?authorization=${token}` : "";
     const url = `${scheme}://${this.opts.host}:${this.opts.port}${path}${query}`;
 
     const wsOpts: WebSocket.ClientOptions = { headers, ...this.opts.tls };


### PR DESCRIPTION
## Summary
- remove query token option and always append `?authorization=`
- default path `/endpoints/ws` and clean auth section
- allow key descriptions and label column as `CO@`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'events' etc.; `npm install` returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a80903e3b88325a7034f0eafb6327e