### PR TITLE
fix: hardcode backoff settings

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -14,15 +14,13 @@
         "username": { "type": "text", "label": "Benutzername", "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
         "password": { "type": "password", "label": "Passwort", "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
         "settingsHeader": { "type": "header", "text": "Verbindungseinstellungen", "size": 2 },
-        "pingIntervalMs": { "type": "number", "label": "Ping-Intervall (ms)", "min": 0, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
+        "pingIntervalMs": { "type": "number", "label": "Ping-Intervall (ms)", "min": 0, "default": 30000, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
         "reconnect": {
           "type": "panel",
           "label": "Reconnect",
           "items": {
-            "minMs": { "type": "number", "label": "Reconnect min (ms)", "min": 200, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
-            "maxMs": { "type": "number", "label": "Reconnect max (ms)", "min": 1000, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
-            "factor": { "type": "number", "label": "Backoff-Faktor", "min": 1, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
-            "jitter": { "type": "number", "label": "Jitter (0..1)", "min": 0, "max": 1, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 }
+            "minMs": { "type": "number", "label": "Reconnect min (ms)", "min": 200, "default": 1000, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
+            "maxMs": { "type": "number", "label": "Reconnect max (ms)", "min": 1000, "default": 30000, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 }
           }
         }
       }

--- a/build/main.js
+++ b/build/main.js
@@ -156,8 +156,6 @@ class GiraEndpointAdapter extends utils.Adapter {
                 reconnect: {
                     minMs: cfg.reconnect?.minMs ?? 1000,
                     maxMs: cfg.reconnect?.maxMs ?? 30000,
-                    factor: cfg.reconnect?.factor ?? 1.7,
-                    jitter: cfg.reconnect?.jitter ?? 0.2,
                 },
                 tls,
             });

--- a/io-package.json
+++ b/io-package.json
@@ -47,9 +47,7 @@
     "pingIntervalMs": 30000,
     "reconnect": {
       "minMs": 1000,
-      "maxMs": 30000,
-      "factor": 1.7,
-      "jitter": 0.2
+      "maxMs": 30000
     },
     "ca": "",
     "cert": "",

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
   username?: string;
   password?: string;
   pingIntervalMs?: number;
-  reconnect?: { minMs?: number; maxMs?: number; factor?: number; jitter?: number };
+  reconnect?: { minMs?: number; maxMs?: number };
   ca?: string;
   cert?: string;
   key?: string;
@@ -148,8 +148,6 @@ class GiraEndpointAdapter extends utils.Adapter {
         reconnect: {
           minMs: cfg.reconnect?.minMs ?? 1000,
           maxMs: cfg.reconnect?.maxMs ?? 30000,
-          factor: cfg.reconnect?.factor ?? 1.7,
-          jitter: cfg.reconnect?.jitter ?? 0.2,
         },
         tls,
       });


### PR DESCRIPTION
## Summary
- remove backoff factor and jitter from admin config and native defaults
- hardcode reconnect backoff factor 1.7 and jitter 0.2 in client
- prefill ping interval and reconnect min/max with defaults in admin UI

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@iobroker%2ftesting)*
- `npm run build` *(fails: Property 'extendObjectAsync' does not exist on type 'GiraEndpointAdapter')*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a80c1c64cc8325bb312dd57b999ed0