### PR TITLE
feat: add toggle for info.lastEvent updates

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -10,22 +10,23 @@
         "port": { "type": "number", "label": "Port", "min": 1, "max": 65535, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
         "ssl": { "type": "checkbox", "label": "TLS (wss://) aktivieren", "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
         "path": { "type": "text", "label": "Pfad", "default": "/endpoints/ws", "placeholder": "/", "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
-        "authHeader": { "type": "header", "text": "Authentifizierung", "size": 2 },
-        "username": { "type": "text", "label": "Benutzername", "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
-        "password": { "type": "password", "label": "Passwort", "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
-        "settingsHeader": { "type": "header", "text": "Verbindungseinstellungen", "size": 2 },
-        "pingIntervalMs": { "type": "number", "label": "Ping-Intervall (ms)", "min": 0, "default": 30000, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
-        "reconnect": {
-          "type": "panel",
-          "label": "Reconnect",
-          "items": {
-            "minMs": { "type": "number", "label": "Reconnect min (ms)", "min": 200, "default": 1000, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
-            "maxMs": { "type": "number", "label": "Reconnect max (ms)", "min": 1000, "default": 30000, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 }
-          }
+          "authHeader": { "type": "header", "text": "Authentifizierung", "size": 2 },
+          "username": { "type": "text", "label": "Benutzername", "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
+          "password": { "type": "password", "label": "Passwort", "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
+          "settingsHeader": { "type": "header", "text": "Verbindungseinstellungen", "size": 2 },
+          "pingIntervalMs": { "type": "number", "label": "Ping-Intervall (ms)", "min": 0, "default": 30000, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
+          "reconnect": {
+            "type": "panel",
+            "label": "Reconnect",
+            "items": {
+              "minMs": { "type": "number", "label": "Reconnect min (ms)", "min": 200, "default": 1000, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 },
+              "maxMs": { "type": "number", "label": "Reconnect max (ms)", "min": 1000, "default": 30000, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 }
+            }
+          },
+          "updateLastEvent": { "type": "checkbox", "label": "info.lastEvent aktualisieren", "default": false, "xs": 12, "sm": 6, "md": 6, "lg": 4, "xl": 4 }
         }
-      }
-    },
-    "keysTab": {
+      },
+      "keysTab": {
       "type": "panel",
       "label": "Keys",
       "items": {

--- a/build/main.js
+++ b/build/main.js
@@ -181,10 +181,12 @@ class GiraEndpointAdapter extends utils.Adapter {
             this.client.on("event", async (payload) => {
                 // Provide full event information for debugging
                 this.log.debug(`Received event: ${JSON.stringify(payload)}`);
-                await this.setStateAsync("info.lastEvent", {
-                    val: JSON.stringify(payload),
-                    ack: true,
-                });
+                if (this.config.updateLastEvent) {
+                    await this.setStateAsync("info.lastEvent", {
+                        val: JSON.stringify(payload),
+                        ack: true,
+                    });
+                }
                 const data = payload?.data;
                 if (!data)
                     return;

--- a/io-package.json
+++ b/io-package.json
@@ -49,12 +49,13 @@
       "minMs": 1000,
       "maxMs": 30000
     },
-    "ca": "",
-    "cert": "",
-    "key": "",
-    "rejectUnauthorized": true,
-    "endpointKeys": []
-  },
+      "ca": "",
+      "cert": "",
+      "key": "",
+      "rejectUnauthorized": true,
+      "updateLastEvent": false,
+      "endpointKeys": []
+    },
   "encryptedNative": ["password"],
   "objects": [],
   "instanceObjects": [

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
   key?: string;
   rejectUnauthorized?: boolean;
   endpointKeys?: string[] | { key: string; name?: string }[] | string;
+  updateLastEvent?: boolean;
 }
 
 class GiraEndpointAdapter extends utils.Adapter {
@@ -176,10 +177,12 @@ class GiraEndpointAdapter extends utils.Adapter {
       this.client.on("event", async (payload: any) => {
         // Provide full event information for debugging
         this.log.debug(`Received event: ${JSON.stringify(payload)}`);
-        await this.setStateAsync("info.lastEvent", {
-          val: JSON.stringify(payload),
-          ack: true,
-        });
+        if (this.config.updateLastEvent) {
+          await this.setStateAsync("info.lastEvent", {
+            val: JSON.stringify(payload),
+            ack: true,
+          });
+        }
 
         const data = payload?.data;
         if (!data) return;


### PR DESCRIPTION
## Summary
- add `updateLastEvent` option to control writing `info.lastEvent`
- expose option as checkbox in adapter config
- only update lastEvent state when option is enabled

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68a81c1376c48325be27e902d7503251