### PR TITLE
Rename keys tab to Endpunkt IDs

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -28,12 +28,12 @@
       },
       "keysTab": {
       "type": "panel",
-      "label": "Keys",
+      "label": "Endpunkt IDs",
       "items": {
-        "subscriptionHeader": { "type": "header", "text": "Subscription", "size": 2 },
+        "subscriptionHeader": { "type": "header", "text": "Liste der Homeserver Endpunkt IDs welche abonniert werden", "size": 2 },
         "endpointKeys": {
           "type": "table",
-          "label": "Endpoint-Keys",
+          "label": "Hier die Endpunkt IDs ohne das CO@ eingeben",
           "items": [
             { "type": "text", "attr": "key", "label": "CO@" },
             { "type": "text", "attr": "name", "label": "Beschreibung" }


### PR DESCRIPTION
## Summary
- rename "Keys" tab to "Endpunkt IDs"
- update subscription header and table descriptions for endpoint IDs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a81ff542f48325aca0f4bf03bf536c