### PR TITLE
chore: use new adapter logo

### DIFF
--- a/admin/gira-endpoint.svg
+++ b/admin/gira-endpoint.svg
@@ -1,4 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
-  <circle cx="32" cy="32" r="30" fill="#006b6b"/>
-  <path d="M32 16a16 16 0 1 0 16 16h-6a10 10 0 1 1-10-10v10h10v-6H32V16z" fill="#fff"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="20" fill="#111111"/>
+  <path d="M20 45 L50 25 L80 45 V85 H20 Z" fill="none" stroke="#008F88" stroke-width="6" stroke-linejoin="round"/>
+  <text x="50" y="72" text-anchor="middle" font-family="sans-serif" font-size="30" font-weight="600" fill="#008F88">
+    WS
+  </text>
 </svg>


### PR DESCRIPTION
## Summary
- replace old adapter icon with new housing WS logo

## Testing
- `npm test` *(fails: Missing script: "test" as no tests defined)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a82fef48f08325bec6ba1e3450304b