### PR TITLE
fix: enable npm provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read               # nötig für checkout
+  id-token: write              # nötig für npm provenance
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
- allow GitHub Actions to fetch OIDC token for npm by granting `id-token: write`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8347ad22483259cfe148417c569ed