### PR TITLE
Secure sensitive config entries

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -31,8 +31,8 @@
     "type": "protocols",
     "connectionType": "cloud",
     "dataSource": "push",
-    "encryptedNative": ["password"],
-    "protectedNative": ["password"],
+    "encryptedNative": ["password", "ca", "cert", "key"],
+    "protectedNative": ["password", "ca", "cert", "key"],
     "dependencies": [{"js-controller": ">=5.0.19"}]
   },
   "native": {


### PR DESCRIPTION
## Summary
- Mark password and TLS credential fields as protected and encrypted in io-package.json

## Testing
- `npm test` (fails: Missing script "test")
- `npx @iobroker/adapter-dev check` (fails: 403 Forbidden - registry access)


------
https://chatgpt.com/codex/tasks/task_e_68a8411466108325ab3d3745050b96f7