### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Variante A (empfohlen): per Tarball installieren
 cd ~/iobroker.gira-endpoint
 git pull --ff-only
 npm run build
-npm pack                   # erzeugt z.B. iobroker.gira-endpoint-0.1.0.tgz
+npm pack                   # erzeugt z.B. iobroker.gira-endpoint-0.2.0.tgz
 
 # ins ioBroker-Verzeichnis und dort installieren (als iobroker-User)
 cd /opt/iobroker
-sudo -u iobroker -H npm i --omit=dev ~/iobroker.gira-endpoint/iobroker.gira-endpoint-0.1.0.tgz
+sudo -u iobroker -H npm i --omit=dev ~/iobroker.gira-endpoint/iobroker.gira-endpoint-0.2.0.tgz
 
 # Dateien hochladen & Instanz anlegen
 iobroker upload gira-endpoint
@@ -61,6 +61,9 @@ iobroker upload gira-endpoint
 Danach Instanz in Admin öffnen und Verbindung einstellen (Host/Port/Path/TLS/Benutzer).
 
 ## Changelog
+
+### 0.2.0
+* Added configurable mapping between ioBroker states and Gira endpoints
 
 ### 0.1.0
 * Adapter basically working and tested

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,12 @@
 {
   "common": {
     "name": "gira-endpoint",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "news": {
+      "0.2.0": {
+        "en": "Add configurable mapping between ioBroker states and Gira endpoints",
+        "de": "Konfigurierbares Mapping zwischen ioBroker-States und Gira-Endpunkten hinzugefügt"
+      },
       "0.1.0": {
         "en": "Adapter basically working and tested",
         "de": "Adapter grob lauffähig und getestet"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.gira-endpoint",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@iobroker/adapter-core": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "ioBroker adapter for Gira endpoint (WS/WSS) – emits events as states, minimal viable replacement for Node-RED Gira node",
   "author": "you",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
## Summary
- bump adapter version to 0.2.0
- document configurable state-to-endpoint mapping in changelog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a85da18df08325bffe95580cdf2ab3