### PR TITLE
fix: handle echoed endpoint values loosely

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -309,7 +309,8 @@ class GiraEndpointAdapter extends utils.Adapter {
                             type = "string";
                     }
                     const pending = this.pendingUpdates.get(normalized);
-                    if (pending !== undefined && pending === value) {
+                    if (pending !== undefined &&
+                        (pending === value || pending == value)) {
                         this.log.debug(`Ignoring echoed event for ${normalized} -> ${JSON.stringify(value)}`);
                         this.pendingUpdates.delete(normalized);
                         continue;

--- a/src/main.ts
+++ b/src/main.ts
@@ -304,19 +304,22 @@ class GiraEndpointAdapter extends utils.Adapter {
             else if (typeof val === "string") type = "string";
           }
 
-            const pending = this.pendingUpdates.get(normalized);
-            if (pending !== undefined && pending === value) {
-              this.log.debug(
-                `Ignoring echoed event for ${normalized} -> ${JSON.stringify(value)}`
-              );
-              this.pendingUpdates.delete(normalized);
-              continue;
-            }
+          const pending = this.pendingUpdates.get(normalized);
+          if (
+            pending !== undefined &&
+            (pending === value || pending == (value as any))
+          ) {
+            this.log.debug(
+              `Ignoring echoed event for ${normalized} -> ${JSON.stringify(value)}`
+            );
             this.pendingUpdates.delete(normalized);
+            continue;
+          }
+          this.pendingUpdates.delete(normalized);
 
-            const id =
-              this.keyIdMap.get(normalized) ?? `objekte.${this.sanitizeId(normalized)}`;
-            this.keyIdMap.set(normalized, id);
+          const id =
+            this.keyIdMap.get(normalized) ?? `objekte.${this.sanitizeId(normalized)}`;
+          this.keyIdMap.set(normalized, id);
           const name = this.keyDescMap.get(normalized) || normalized;
           this.keyDescMap.set(normalized, name);
           await this.extendObjectAsync(id, {


### PR DESCRIPTION
## Summary
- Avoid repeated endpoint updates by comparing pending values using loose equality
- Update generated build output

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8e171f5048325b014acd083cfa848