### PR TITLE
Add boolean conversion for simple endpoints and adjust mapping layout

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -157,6 +157,12 @@
               "type": "text",
               "attr": "name",
               "label": "Beschreibung"
+            },
+            {
+              "type": "checkbox",
+              "attr": "bool",
+              "label": "0/1 ↔ true/false",
+              "default": false
             }
           ]
         }
@@ -191,9 +197,14 @@
               "label": "CO@"
             },
             {
+              "type": "text",
+              "attr": "name",
+              "label": "Beschreibung"
+            },
+            {
               "type": "checkbox",
               "attr": "toEndpoint",
-              "label": "ioBroker Objekt → Endpunkt",
+              "label": "ioBroker → Endpunkt",
               "default": true
             },
             {
@@ -207,11 +218,6 @@
               "attr": "bool",
               "label": "0/1 ↔ true/false",
               "default": false
-            },
-            {
-              "type": "text",
-              "attr": "name",
-              "label": "Beschreibung"
             }
           ]
         }

--- a/build/main.js
+++ b/build/main.js
@@ -96,6 +96,7 @@ class GiraEndpointAdapter extends utils.Adapter {
             const username = String(cfg.username ?? "");
             const password = String(cfg.password ?? "");
             const pingIntervalMs = Number(cfg.pingIntervalMs ?? 30000);
+            const boolKeys = new Set();
             const rawKeys = cfg.endpointKeys;
             const endpointKeys = [];
             if (Array.isArray(rawKeys)) {
@@ -107,6 +108,9 @@ class GiraEndpointAdapter extends utils.Adapter {
                         const name = String(k.name ?? "").trim();
                         if (name)
                             this.keyDescMap.set(key, name);
+                        const bool = Boolean(k.bool);
+                        if (bool)
+                            boolKeys.add(key);
                         endpointKeys.push(key);
                     }
                     else {
@@ -127,7 +131,6 @@ class GiraEndpointAdapter extends utils.Adapter {
             }
             const forwardMap = new Map();
             const reverseMap = new Map();
-            const boolKeys = new Set();
             if (Array.isArray(cfg.mappings)) {
                 for (const m of cfg.mappings) {
                     if (typeof m !== "object" || !m)

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
   cert?: string;
   key?: string;
   rejectUnauthorized?: boolean;
-  endpointKeys?: string[] | { key: string; name?: string }[] | string;
+  endpointKeys?: string[] | { key: string; name?: string; bool?: boolean }[] | string;
   updateLastEvent?: boolean;
   mappings?: {
     stateId: string;
@@ -95,6 +95,8 @@ class GiraEndpointAdapter extends utils.Adapter {
       const password = String(cfg.password ?? "");
       const pingIntervalMs = Number(cfg.pingIntervalMs ?? 30000);
 
+      const boolKeys = new Set<string>();
+
       const rawKeys = cfg.endpointKeys;
       const endpointKeys: string[] = [];
       if (Array.isArray(rawKeys)) {
@@ -104,6 +106,8 @@ class GiraEndpointAdapter extends utils.Adapter {
             if (!key) continue;
             const name = String((k as any).name ?? "").trim();
             if (name) this.keyDescMap.set(key, name);
+            const bool = Boolean((k as any).bool);
+            if (bool) boolKeys.add(key);
             endpointKeys.push(key);
           } else {
             const key = this.normalizeKey(String(k).trim());
@@ -122,7 +126,6 @@ class GiraEndpointAdapter extends utils.Adapter {
 
       const forwardMap = new Map<string, { key: string; bool: boolean }>();
       const reverseMap = new Map<string, { stateId: string; bool: boolean }>();
-      const boolKeys = new Set<string>();
       if (Array.isArray(cfg.mappings)) {
         for (const m of cfg.mappings) {
           if (typeof m !== "object" || !m) continue;


### PR DESCRIPTION
## Summary
- add option to convert 0/1 to true/false for simple endpoints
- reorder mapping table and rename ioBroker direction label

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8e678f60c8325aedb11585069a32f