### PR TITLE
Specify license type

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -27,7 +27,8 @@
     "authors": ["you"],
     "keywords": ["gira", "homeserver", "websocket"],
     "licenseInformation": {
-      "license": "GPL-3.0-or-later"
+      "license": "GPL-3.0-or-later",
+      "type": "free"
     },
     "enabled": true,
     "materialize": false,


### PR DESCRIPTION
## Summary
- specify license type 'free' in io-package.json

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run build` *(fails: tsc not found, dependencies not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68a98f097b8c83259eed681b2322024f