### PR TITLE
Add ioBroker keyword to package metadata

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -25,7 +25,7 @@
     "icon": "gira-endpoint.svg",
       "extIcon": "https://raw.githubusercontent.com/dosordie/iobroker.gira-endpoint/main/admin/gira-endpoint.svg",
     "authors": ["you"],
-    "keywords": ["gira", "homeserver", "websocket"],
+    "keywords": ["ioBroker", "gira", "homeserver", "websocket"],
     "licenseInformation": {
       "license": "GPL-3.0-or-later",
       "type": "free"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "node": ">=18"
   },
   "keywords": [
+    "ioBroker",
     "gira",
     "homeserver",
     "websocket"


### PR DESCRIPTION
## Summary
- ensure package and io-package keywords include "ioBroker"

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a99025b8848325a229299e5d599f35