### PR TITLE
Add basic test setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ iobroker upload gira-endpoint
 
 Danach Instanz in Admin öffnen und Verbindung einstellen (Host/Port/Path/TLS/Benutzer).
 
+## Tests
+
+Die Tests können mit `npm test` ausgeführt werden.
+
 ## Changelog
 
 ### 0.2.0

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "build": "tsc -p .",
     "watch": "tsc -w -p .",
-    "start": "node build/main.js"
+    "start": "node build/main.js",
+    "test": "node test/main.test.js"
   },
   "engines": {
     "node": ">=18"

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,0 +1,7 @@
+const path = require("path");
+const { tests } = require("@iobroker/testing");
+
+// Run basic integration tests for the adapter
+// This will use the default ioBroker testing harness
+// and ensure the adapter can be started and stopped.
+tests.integration(path.join(__dirname, ".."));


### PR DESCRIPTION
## Summary
- add example test harness using `@iobroker/testing`
- wire up `npm test` script and document usage
- run tests in CI with a new GitHub Actions workflow

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@iobroker%2ftesting)*
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68a993653e408325b0a5ccfc4379092e