### PR TITLE
feat: rename endpoint object folder

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -26,5 +26,6 @@
   "Hier die Endpunkt IDs und ioBroker Objekte eintragen": "Hier die Endpunkt IDs und ioBroker Objekte eintragen",
   "State ID": "State ID",
   "ioBroker → Endpunkt": "ioBroker → Endpunkt",
-  "Endpunkt → ioBroker": "Endpunkt → ioBroker"
+  "Endpunkt → ioBroker": "Endpunkt → ioBroker",
+  "confirmDeleteRow": "\"%s\" wirklich löschen?"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -26,5 +26,6 @@
   "Hier die Endpunkt IDs und ioBroker Objekte eintragen": "Enter endpoint IDs and ioBroker objects here",
   "State ID": "State ID",
   "ioBroker → Endpunkt": "ioBroker → Endpoint",
-  "Endpunkt → ioBroker": "Endpoint → ioBroker"
+  "Endpunkt → ioBroker": "Endpoint → ioBroker",
+  "confirmDeleteRow": "Really delete \"%s\"?"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -161,6 +161,10 @@
               "attr": "updateOnStart",
               "label": "Beim Start aktualisieren",
               "default": true
+            },
+            {
+              "type": "delete",
+              "confirm": "confirmDeleteRow"
             }
           ]
         }
@@ -225,6 +229,10 @@
               "attr": "updateOnStart",
               "label": "Beim Start aktualisieren",
               "default": true
+            },
+            {
+              "type": "delete",
+              "confirm": "confirmDeleteRow"
             }
           ]
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,9 +84,9 @@ class GiraEndpointAdapter extends utils.Adapter {
         await this.setStateAsync("info.connection", { val: false, ack: true });
         this.log.debug("Pre-created info states");
 
-      await this.setObjectNotExistsAsync("objekte", {
+      await this.setObjectNotExistsAsync("CO@", {
         type: "channel",
-        common: { name: "Objekte" },
+        common: { name: "CO@" },
         native: {},
       });
 
@@ -192,7 +192,7 @@ class GiraEndpointAdapter extends utils.Adapter {
 
       // Pre-create configured endpoint states so they appear immediately in ioBroker
       for (const key of new Set(this.endpointKeys)) {
-        const id = `objekte.${this.sanitizeId(key)}`;
+        const id = `CO@.${this.sanitizeId(key)}`;
         this.keyIdMap.set(key, id);
         const name = this.keyDescMap.get(key) || key;
         await this.setObjectNotExistsAsync(id, {
@@ -202,6 +202,24 @@ class GiraEndpointAdapter extends utils.Adapter {
         });
         this.log.debug(`Pre-created endpoint state ${id}`);
         this.subscribeStates(id);
+      }
+
+      const validIds = new Set(this.keyIdMap.values());
+      const objs = await this.getAdapterObjectsAsync();
+      for (const id of Object.keys(objs)) {
+        if (id.startsWith("CO@.")) {
+          if (!validIds.has(id)) {
+            await this.delObjectAsync(id);
+            this.log.debug(`Removed stale endpoint state ${id}`);
+          }
+        } else if (id.startsWith("objekte.")) {
+          await this.delObjectAsync(id);
+        }
+      }
+      try {
+        await this.delObjectAsync("objekte", { recursive: true });
+      } catch {
+        /* ignore */
       }
 
       const ca = cfg.ca ? String(cfg.ca) : undefined;
@@ -336,7 +354,7 @@ class GiraEndpointAdapter extends utils.Adapter {
           this.pendingUpdates.delete(normalized);
 
           const id =
-            this.keyIdMap.get(normalized) ?? `objekte.${this.sanitizeId(normalized)}`;
+            this.keyIdMap.get(normalized) ?? `CO@.${this.sanitizeId(normalized)}`;
           this.keyIdMap.set(normalized, id);
           const name = this.keyDescMap.get(normalized) || normalized;
           this.keyDescMap.set(normalized, name);
@@ -400,7 +418,7 @@ class GiraEndpointAdapter extends utils.Adapter {
   }
 
   private sanitizeId(s: string): string {
-    return s.replace(/[^a-z0-9@_\-\.]/gi, "_").toUpperCase();
+    return s.replace(/^CO@/i, "").replace(/[^a-z0-9@_\-\.]/gi, "_").toLowerCase();
   }
 
   private async onUnload(callback: () => void): Promise<void> {
@@ -461,7 +479,7 @@ class GiraEndpointAdapter extends utils.Adapter {
         }
       }
       this.client.send({ type: "call", param: { key: mapped.key, method: "set", value: uidValue } });
-      const mappedId = this.keyIdMap.get(mapped.key) ?? `objekte.${this.sanitizeId(mapped.key)}`;
+      const mappedId = this.keyIdMap.get(mapped.key) ?? `CO@.${this.sanitizeId(mapped.key)}`;
       this.keyIdMap.set(mapped.key, mappedId);
       this.setState(mappedId, { val: ackVal, ack: true });
       this.pendingUpdates.set(mapped.key, ackVal);


### PR DESCRIPTION
## Summary
- rename object channel to `CO@`
- drop `CO@` prefix and uppercase from state IDs
- add safety confirmation when removing rows in admin tables and clean up deleted objects

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@iobroker%2ftesting)*
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing')*


------
https://chatgpt.com/codex/tasks/task_e_68a9c00e022c832599b4017d0dbc5ffb