### PR TITLE
fix admin table schema error

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -26,6 +26,5 @@
   "Hier die Endpunkt IDs und ioBroker Objekte eintragen": "Hier die Endpunkt IDs und ioBroker Objekte eintragen",
   "State ID": "State ID",
   "ioBroker → Endpunkt": "ioBroker → Endpunkt",
-  "Endpunkt → ioBroker": "Endpunkt → ioBroker",
-  "confirmDeleteRow": "\"%s\" wirklich löschen?"
+  "Endpunkt → ioBroker": "Endpunkt → ioBroker"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -26,6 +26,5 @@
   "Hier die Endpunkt IDs und ioBroker Objekte eintragen": "Enter endpoint IDs and ioBroker objects here",
   "State ID": "State ID",
   "ioBroker → Endpunkt": "ioBroker → Endpoint",
-  "Endpunkt → ioBroker": "Endpoint → ioBroker",
-  "confirmDeleteRow": "Really delete \"%s\"?"
+  "Endpunkt → ioBroker": "Endpoint → ioBroker"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -161,10 +161,6 @@
               "attr": "updateOnStart",
               "label": "Beim Start aktualisieren",
               "default": true
-            },
-            {
-              "type": "delete",
-              "confirm": "confirmDeleteRow"
             }
           ]
         }
@@ -229,10 +225,6 @@
               "attr": "updateOnStart",
               "label": "Beim Start aktualisieren",
               "default": true
-            },
-            {
-              "type": "delete",
-              "confirm": "confirmDeleteRow"
             }
           ]
         }


### PR DESCRIPTION
## Summary
- remove deprecated delete table column from admin config
- drop unused confirmation strings in translations

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cb5ae3fc8325a9c22e7469fdf4b6