### PR TITLE
Add confirmation and cleanup for endpoint deletions

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -139,6 +139,7 @@
           "md": 12,
           "lg": 12,
           "xl": 12,
+          "confirmRowDelete": true,
           "items": [
             {
               "type": "text",
@@ -186,6 +187,7 @@
           "md": 12,
           "lg": 12,
           "xl": 12,
+          "confirmRowDelete": true,
           "items": [
             {
               "type": "text",

--- a/build/main.js
+++ b/build/main.js
@@ -205,17 +205,18 @@ class GiraEndpointAdapter extends utils.Adapter {
             }
             const validIds = new Set(this.keyIdMap.values());
             const objs = await this.getAdapterObjectsAsync();
-            for (const id of Object.keys(objs)) {
+            for (const fullId of Object.keys(objs)) {
+                const id = fullId.startsWith(this.namespace + ".")
+                    ? fullId.slice(this.namespace.length + 1)
+                    : fullId;
                 if (id.startsWith("CO@.")) {
                     if (!validIds.has(id)) {
-                        await this.delStateAsync(id);
-                        await this.delObjectAsync(id);
+                        await this.delObjectAsync(id, { recursive: true });
                         this.log.debug(`Removed stale endpoint state ${id}`);
                     }
                 }
                 else if (id.startsWith("objekte.")) {
-                    await this.delStateAsync(id);
-                    await this.delObjectAsync(id);
+                    await this.delObjectAsync(id, { recursive: true });
                 }
             }
             try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -206,16 +206,17 @@ class GiraEndpointAdapter extends utils.Adapter {
 
       const validIds = new Set(this.keyIdMap.values());
       const objs = await this.getAdapterObjectsAsync();
-      for (const id of Object.keys(objs)) {
+      for (const fullId of Object.keys(objs)) {
+        const id = fullId.startsWith(this.namespace + ".")
+          ? fullId.slice(this.namespace.length + 1)
+          : fullId;
         if (id.startsWith("CO@.")) {
           if (!validIds.has(id)) {
-            await this.delStateAsync(id);
-            await this.delObjectAsync(id);
+            await this.delObjectAsync(id, { recursive: true });
             this.log.debug(`Removed stale endpoint state ${id}`);
           }
         } else if (id.startsWith("objekte.")) {
-          await this.delStateAsync(id);
-          await this.delObjectAsync(id);
+          await this.delObjectAsync(id, { recursive: true });
         }
       }
       try {


### PR DESCRIPTION
## Summary
- ask for confirmation before removing endpoint or mapping rows in the admin UI
- clean up orphaned endpoint states when configuration changes

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cdbad488832596d8583960d49ba5