### PR TITLE
fix: enable delete confirmation in tables

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -139,7 +139,7 @@
           "md": 12,
           "lg": 12,
           "xl": 12,
-          "confirmRowDelete": true,
+          "confirmDelete": true,
           "items": [
             {
               "type": "text",
@@ -187,7 +187,7 @@
           "md": 12,
           "lg": 12,
           "xl": 12,
-          "confirmRowDelete": true,
+          "confirmDelete": true,
           "items": [
             {
               "type": "text",


### PR DESCRIPTION
## Summary
- replace invalid `confirmRowDelete` with `confirmDelete` so deleting rows prompts for confirmation

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68a9d0889eb08325a114ce5dd4e0972c