### PR TITLE
Remove unsupported confirmDelete option from admin config

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -139,7 +139,6 @@
           "md": 12,
           "lg": 12,
           "xl": 12,
-          "confirmDelete": true,
           "items": [
             {
               "type": "text",
@@ -187,7 +186,6 @@
           "md": 12,
           "lg": 12,
           "xl": 12,
-          "confirmDelete": true,
           "items": [
             {
               "type": "text",


### PR DESCRIPTION
## Summary
- fix invalid admin jsonConfig by dropping unsupported confirmDelete option from table widgets

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@iobroker%2ftesting)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d2b6df3c832586ef75227ddf4659