### PR TITLE
fix: restore delete confirmation in admin tables

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -134,6 +134,7 @@
           "style": {
             "fontSize": "0.8rem"
           },
+          "confirmRowDelete": true,
           "xs": 12,
           "sm": 12,
           "md": 12,
@@ -181,6 +182,7 @@
           "style": {
             "fontSize": "0.8rem"
           },
+          "confirmRowDelete": true,
           "xs": 12,
           "sm": 12,
           "md": 12,


### PR DESCRIPTION
## Summary
- ask for confirmation before removing rows in `endpointKeys` and `mappings` tables

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*


------
https://chatgpt.com/codex/tasks/task_e_68a9daa334e48325b5f302035b6b7bda