### PR TITLE
fix: remove unsupported confirmRowDelete

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -134,7 +134,6 @@
           "style": {
             "fontSize": "0.8rem"
           },
-          "confirmRowDelete": true,
           "xs": 12,
           "sm": 12,
           "md": 12,
@@ -182,7 +181,6 @@
           "style": {
             "fontSize": "0.8rem"
           },
-          "confirmRowDelete": true,
           "xs": 12,
           "sm": 12,
           "md": 12,


### PR DESCRIPTION
## Summary
- remove unsupported confirmRowDelete option from jsonConfig tables

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68a9dc092f4c83258e2bb3efc11a3e9b