### PR TITLE
fix: send normalized key for adapter states

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Wenn er dir gefällt oder dir weiterhilft, freue ich mich über eine kleine Spen
 
 ## Changelog
 
+### 0.2.2
+* Fix sending adapter states without "CO@" prefix to the HomeServer
+
 ### 0.2.1
 * Allow disabling initial update per endpoint on adapter start
 

--- a/build/main.js
+++ b/build/main.js
@@ -589,7 +589,7 @@ class GiraEndpointAdapter extends utils.Adapter {
             }
         }
         const normKey = this.normalizeKey(key);
-        this.client.send({ type: "call", param: { key, method, value: uidValue } });
+        this.client.send({ type: "call", param: { key: normKey, method, value: uidValue } });
         const mappedForeign = this.reverseMap.get(normKey);
         if (mappedForeign) {
             let mappedVal = ackVal;

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,12 @@
 {
   "common": {
     "name": "gira-endpoint",
-    "version": "0.2.1",
+    "version": "0.2.2",
     "news": {
+      "0.2.2": {
+        "en": "Fix sending adapter states without prefix to HomeServer",
+        "de": "Adapter-eigene States wurden ohne Prefix an den HomeServer gesendet"
+      },
       "0.2.1": {
         "en": "Allow disabling initial update per endpoint on adapter start",
         "de": "Initiale Aktualisierung pro Endpunkt beim Start deaktivierbar"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.gira-endpoint",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@iobroker/adapter-core": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "ioBroker adapter for Gira endpoint (WS/WSS) – emits events as states, minimal viable replacement for Node-RED Gira node",
   "author": "you",
   "license": "GPL-3.0-or-later",

--- a/src/main.ts
+++ b/src/main.ts
@@ -578,7 +578,7 @@ class GiraEndpointAdapter extends utils.Adapter {
       }
     }
     const normKey = this.normalizeKey(key);
-    this.client.send({ type: "call", param: { key, method, value: uidValue } });
+    this.client.send({ type: "call", param: { key: normKey, method, value: uidValue } });
     const mappedForeign = this.reverseMap.get(normKey);
     if (mappedForeign) {
       let mappedVal = ackVal;


### PR DESCRIPTION
## Summary
- fix sending adapter-owned states without CO@ prefix to HomeServer
- document bugfix in changelog

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*


------
https://chatgpt.com/codex/tasks/task_e_68aa1a31d84483258171d14b6b877606