### PR TITLE
Track subscription status and expose state

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -229,6 +229,17 @@
           ]
         }
       }
+    },
+    "subscriptionsTab": {
+      "type": "panel",
+      "label": "Abonnements",
+      "items": {
+        "subscriptionsTable": {
+          "type": "stateList",
+          "label": "Abonnementstatus",
+          "pattern": "info.subscriptions.*"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Maintain a list of pending subscription requests and expose their status under `info.subscriptions.*`.
- Notify admins when a subscription fails or no response is received.
- Add admin UI tab to show subscription status states.

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install` *(fails: 403 Forbidden for @iobroker/testing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1c7f2090832596037a2ad2c71e8e