### PR TITLE
fix: display subscriptions via pattern component

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -235,7 +235,7 @@
       "label": "Abonnements",
       "items": {
         "subscriptionsTable": {
-          "type": "stateList",
+          "type": "pattern",
           "label": "Abonnementstatus",
           "pattern": "info.subscriptions.*"
         }


### PR DESCRIPTION
## Summary
- switch subscriptions tab to use supported `pattern` component

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@iobroker%2ftesting)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1e821ed08325802814db1543b620