### PR TITLE
Populate subscription status without explicit keys

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -300,9 +300,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                     return;
                 const entries = [];
                 // Case 1: subscription result lists multiple items
-                if (this.pendingSubscriptions.size &&
-                    typeof data === "object" &&
-                    Array.isArray(data.items)) {
+                if (typeof data === "object" && Array.isArray(data.items)) {
                     const received = new Set();
                     for (const item of data.items) {
                         if (!item)

--- a/src/main.ts
+++ b/src/main.ts
@@ -309,11 +309,7 @@ class GiraEndpointAdapter extends utils.Adapter {
         const entries: Array<{ key: string; value: any }> = [];
 
         // Case 1: subscription result lists multiple items
-        if (
-          this.pendingSubscriptions.size &&
-          typeof data === "object" &&
-          Array.isArray((data as any).items)
-        ) {
+        if (typeof data === "object" && Array.isArray((data as any).items)) {
           const received = new Set<string>();
           for (const item of (data as any).items) {
             if (!item) continue;


### PR DESCRIPTION
## Summary
- ensure subscription responses create info.subscriptions states even when no specific keys are pending

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68aa2082c73c8325bd9c63906254af5f