### PR TITLE
Fix empty subscription tab display

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -214,8 +214,16 @@ class GiraEndpointAdapter extends utils.Adapter {
                 });
                 this.log.debug(`Pre-created endpoint state ${id}`);
                 this.subscribeStates(id);
+                const subId = `info.subscriptions.${this.sanitizeId(key)}`;
+                await this.setObjectNotExistsAsync(subId, {
+                    type: "state",
+                    common: { name: key, type: "boolean", role: "indicator", read: true, write: false },
+                    native: {},
+                });
+                await this.setStateAsync(subId, { val: false, ack: true });
             }
             const validIds = new Set(this.keyIdMap.values());
+            const validSubIds = new Set(this.endpointKeys.map((k) => `info.subscriptions.${this.sanitizeId(k)}`));
             const objs = await this.getAdapterObjectsAsync();
             for (const fullId of Object.keys(objs)) {
                 const id = fullId.startsWith(this.namespace + ".")
@@ -224,6 +232,14 @@ class GiraEndpointAdapter extends utils.Adapter {
                 if (id.startsWith("CO@.")) {
                     if (!validIds.has(id)) {
                         const msg = `Deleting stale endpoint state ${id}`;
+                        this.log.info(msg);
+                        this.notifyAdmin(msg);
+                        await this.delObjectAsync(id, { recursive: true });
+                    }
+                }
+                else if (id.startsWith("info.subscriptions.")) {
+                    if (!validSubIds.has(id)) {
+                        const msg = `Deleting stale subscription state ${id}`;
                         this.log.info(msg);
                         this.notifyAdmin(msg);
                         await this.delObjectAsync(id, { recursive: true });


### PR DESCRIPTION
## Summary
- pre-create subscription states and default them to false
- remove stale subscription states when configuration changes

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install` *(fails: 403 Forbidden for @iobroker/testing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa22ffd9ac832599add7ab74165eab