### PR TITLE
fix: show subscription tab and reset states

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -237,7 +237,7 @@
         "subscriptionsTable": {
           "type": "pattern",
           "label": "Abonnementstatus",
-          "pattern": "info.subscriptions.*"
+          "pattern": "%INSTANCE%.info.subscriptions.*"
         }
       }
     }

--- a/build/main.js
+++ b/build/main.js
@@ -297,6 +297,11 @@ class GiraEndpointAdapter extends utils.Adapter {
             this.client.on("close", (info) => {
                 this.log.warn(`Connection closed (${info?.code || "?"}) ${info?.reason || ""}`);
                 this.setState("info.connection", false, true);
+                this.getStatesAsync("info.subscriptions.*").then((states) => {
+                    for (const id of Object.keys(states)) {
+                        this.setState(id, { val: false, ack: true });
+                    }
+                }).catch(() => { });
             });
             this.client.on("error", (err) => {
                 this.log.error(`Client error: ${err?.message || err}`);
@@ -603,6 +608,10 @@ class GiraEndpointAdapter extends utils.Adapter {
             }
             else {
                 this.client.unsubscribe(keys);
+                for (const k of keys) {
+                    const subId = `info.subscriptions.${this.sanitizeId(k)}`;
+                    this.setState(subId, { val: false, ack: true });
+                }
             }
             this.setState(id, { val: state.val, ack: true });
             return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -304,6 +304,11 @@ class GiraEndpointAdapter extends utils.Adapter {
       this.client.on("close", (info: any) => {
         this.log.warn(`Connection closed (${info?.code || "?"}) ${info?.reason || ""}`);
         this.setState("info.connection", false, true);
+        this.getStatesAsync("info.subscriptions.*").then((states) => {
+          for (const id of Object.keys(states)) {
+            this.setState(id, { val: false, ack: true });
+          }
+        }).catch(() => {/* ignore */});
       });
 
       this.client.on("error", (err: any) => {
@@ -602,6 +607,10 @@ class GiraEndpointAdapter extends utils.Adapter {
         this.client.subscribe(keys);
       } else {
         this.client.unsubscribe(keys);
+        for (const k of keys) {
+          const subId = `info.subscriptions.${this.sanitizeId(k)}`;
+          this.setState(subId, { val: false, ack: true });
+        }
       }
       this.setState(id, { val: state.val, ack: true });
       return;


### PR DESCRIPTION
## Summary
- show subscription status in admin tab by referencing instance-specific states
- reset subscription states when connection closes or an unsubscribe command is issued

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*


------
https://chatgpt.com/codex/tasks/task_e_68aa277807ac8325a02edf07d540f9c8