### PR TITLE
fix: add explicit states type to resolve TS error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -304,7 +304,7 @@ class GiraEndpointAdapter extends utils.Adapter {
       this.client.on("close", (info: any) => {
         this.log.warn(`Connection closed (${info?.code || "?"}) ${info?.reason || ""}`);
         this.setState("info.connection", false, true);
-        this.getStatesAsync("info.subscriptions.*").then((states) => {
+        this.getStatesAsync("info.subscriptions.*").then((states: Record<string, ioBroker.State | null>) => {
           for (const id of Object.keys(states)) {
             this.setState(id, { val: false, ack: true });
           }


### PR DESCRIPTION
## Summary
- specify a `Record<string, ioBroker.State | null>` type for `states` in `getStatesAsync` callback to avoid implicit any

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68aa28663628832582c26d26b9c12e7e