### PR TITLE
fix: detect failed subscriptions

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -331,7 +331,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                             continue;
                         const normalized = this.normalizeKey(key);
                         received.add(normalized);
-                        const success = !("error" in item);
+                        const success = item.code !== undefined ? item.code === 0 : !("error" in item);
                         const subId = `info.subscriptions.${this.sanitizeId(normalized)}`;
                         await this.extendObjectAsync(subId, {
                             type: "state",

--- a/src/main.ts
+++ b/src/main.ts
@@ -341,7 +341,8 @@ class GiraEndpointAdapter extends utils.Adapter {
             if (key === undefined) continue;
             const normalized = this.normalizeKey(key);
             received.add(normalized);
-            const success = !("error" in item);
+            const success =
+              item.code !== undefined ? item.code === 0 : !("error" in item);
             const subId = `info.subscriptions.${this.sanitizeId(normalized)}`;
             await this.extendObjectAsync(subId, {
               type: "state",


### PR DESCRIPTION
## Summary
- correctly detect failed subscription responses (code != 0)

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*


------
https://chatgpt.com/codex/tasks/task_e_68aa2a6b31e083258b92c031e5d85f52