### PR TITLE
fix: show subscription status in admin

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -26,5 +26,7 @@
   "Hier die Endpunkt IDs und ioBroker Objekte eintragen": "Hier die Endpunkt IDs und ioBroker Objekte eintragen",
   "State ID": "State ID",
   "ioBroker → Endpunkt": "ioBroker → Endpunkt",
-  "Endpunkt → ioBroker": "Endpunkt → ioBroker"
+  "Endpunkt → ioBroker": "Endpunkt → ioBroker",
+  "Abonnements": "Abonnements",
+  "Abonnementstatus": "Abonnementstatus"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -26,5 +26,7 @@
   "Hier die Endpunkt IDs und ioBroker Objekte eintragen": "Enter endpoint IDs and ioBroker objects here",
   "State ID": "State ID",
   "ioBroker → Endpunkt": "ioBroker → Endpoint",
-  "Endpunkt → ioBroker": "Endpoint → ioBroker"
+  "Endpunkt → ioBroker": "Endpoint → ioBroker",
+  "Abonnements": "Subscriptions",
+  "Abonnementstatus": "Subscription status"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -237,7 +237,7 @@
         "subscriptionsTable": {
           "type": "pattern",
           "label": "Abonnementstatus",
-          "pattern": "info.subscriptions.*"
+          "pattern": ":instance:.info.subscriptions.*"
         }
       }
     }


### PR DESCRIPTION
## Summary
- show subscription status states for current instance in admin
- add missing translations for subscription tab

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@iobroker%2ftesting)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2d58c01c8325ae1463b1da55c9ce