### PR TITLE
Remove subscription status tab from admin UI

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -26,7 +26,5 @@
   "Hier die Endpunkt IDs und ioBroker Objekte eintragen": "Hier die Endpunkt IDs und ioBroker Objekte eintragen",
   "State ID": "State ID",
   "ioBroker → Endpunkt": "ioBroker → Endpunkt",
-  "Endpunkt → ioBroker": "Endpunkt → ioBroker",
-  "Abonnements": "Abonnements",
-  "Abonnementstatus": "Abonnementstatus"
+  "Endpunkt → ioBroker": "Endpunkt → ioBroker"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -26,7 +26,5 @@
   "Hier die Endpunkt IDs und ioBroker Objekte eintragen": "Enter endpoint IDs and ioBroker objects here",
   "State ID": "State ID",
   "ioBroker → Endpunkt": "ioBroker → Endpoint",
-  "Endpunkt → ioBroker": "Endpoint → ioBroker",
-  "Abonnements": "Subscriptions",
-  "Abonnementstatus": "Subscription status"
+  "Endpunkt → ioBroker": "Endpoint → ioBroker"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -229,17 +229,6 @@
           ]
         }
       }
-    },
-    "subscriptionsTab": {
-      "type": "panel",
-      "label": "Abonnements",
-      "items": {
-        "subscriptionsTable": {
-          "type": "pattern",
-          "label": "Abonnementstatus",
-          "pattern": ":instance:.info.subscriptions.*"
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove broken subscriptions tab from admin config
- drop translations for removed tab

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@iobroker%2ftesting)*
- `npm test` *(fails: Cannot find module '@iobroker/testing')*


------
https://chatgpt.com/codex/tasks/task_e_68aa2e94bd5c83258bb82156da082222