### PR TITLE
refactor: remove control states

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -483,25 +483,6 @@ class GiraEndpointAdapter extends utils.Adapter {
         }
       });
 
-      await this.setObjectNotExistsAsync("control", {
-        type: "channel",
-        common: { name: "Control" },
-        native: {},
-      });
-      await this.setObjectNotExistsAsync("control.subscribe", {
-        type: "state",
-        common: { name: "Subscribe keys", type: "string", role: "state", read: false, write: true },
-        native: {},
-      });
-      await this.setObjectNotExistsAsync("control.unsubscribe", {
-        type: "state",
-        common: { name: "Unsubscribe keys", type: "string", role: "state", read: false, write: true },
-        native: {},
-      });
-      this.log.debug("Created control states");
-      this.subscribeStates("control.subscribe");
-      this.subscribeStates("control.unsubscribe");
-
       this.client.connect();
     } catch (e: any) {
       this.log.error(`onReady failed: ${e?.message || e}`);
@@ -596,27 +577,6 @@ class GiraEndpointAdapter extends utils.Adapter {
     if (state.ack) return;
     const key = id.split(".").pop();
     if (!key) return;
-    if (key === "subscribe" || key === "unsubscribe") {
-      const keys = String(state.val || "")
-        .split(/[,;\s]+/)
-        .map((k) => k.trim())
-        .filter((k) => k)
-        .map((k) => this.normalizeKey(k));
-      if (!keys.length) return;
-      if (key === "subscribe") {
-        for (const k of keys) this.pendingSubscriptions.add(k);
-        this.client.subscribe(keys);
-      } else {
-        this.client.unsubscribe(keys);
-        for (const k of keys) {
-          const subId = `info.subscriptions.${this.sanitizeId(k)}`;
-          this.setState(subId, { val: false, ack: true });
-        }
-      }
-      this.setState(id, { val: state.val, ack: true });
-      return;
-    }
-
     let uidValue: any = state.val;
     let method = "set";
     let ackVal: any = state.val;


### PR DESCRIPTION
## Summary
- remove creation of control channel and related subscribe/unsubscribe states
- drop special handling for control.subscribe/control.unsubscribe

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install` *(fails: 403 Forbidden for @iobroker/testing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2fb203c88325b38be5331bcc8b95