### PR TITLE
Emit error events for non-zero payload codes

### DIFF
--- a/src/lib/GiraClient.ts
+++ b/src/lib/GiraClient.ts
@@ -115,6 +115,19 @@ export class GiraClient extends EventEmitter {
         try { payload = JSON.parse(text); } catch {
           payload = { raw: text };
         }
+        if (
+          payload &&
+          typeof payload === "object" &&
+          payload.code !== undefined &&
+          payload.code !== 0
+        ) {
+          const msg =
+            (payload as any).message ||
+            (payload as any).error ||
+            `Error code ${payload.code}`;
+          this.emit("error", new Error(msg));
+          return;
+        }
         this.normalizeData(payload?.data);
         this.emit("event", payload);
       } catch (err) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -312,8 +312,10 @@ class GiraEndpointAdapter extends utils.Adapter {
       });
 
       this.client.on("error", (err: any) => {
-        this.log.error(`Client error: ${err?.message || err}`);
+        const msg = `Client error: ${err?.message || err}`;
+        this.log.error(msg);
         this.setState("info.lastError", String(err?.message || err), true);
+        this.notifyAdmin(msg);
       });
 
       this.client.on("event", async (payload: any) => {


### PR DESCRIPTION
## Summary
- Emit an error event when received payload indicates a non-zero code
- Notify admin on client errors

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm ci` *(fails: 403 Forbidden fetching @iobroker/testing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4425d98883258a102ae12d7ad03e