### PR TITLE
Refactor select param structure

### DIFF
--- a/build/lib/GiraClient.js
+++ b/build/lib/GiraClient.js
@@ -24,7 +24,7 @@ class GiraClient extends events_1.EventEmitter {
             path: "/",
             username: "",
             password: "",
-            authHeader: true,
+            authHeader: false,
             pingIntervalMs: 30000,
             reconnect: { minMs: 1000, maxMs: 30000 },
             tls: {},
@@ -150,7 +150,7 @@ class GiraClient extends events_1.EventEmitter {
         this.send(msg);
     }
     select(filter, context) {
-        const msg = { type: "select", param: { filter } };
+        const msg = { type: "select", param: filter };
         if (context) {
             msg.context = context;
             return new Promise((resolve, reject) => {

--- a/src/lib/GiraClient.ts
+++ b/src/lib/GiraClient.ts
@@ -206,7 +206,7 @@ export class GiraClient extends EventEmitter {
   }
 
   public select(filter: object, context?: string): Promise<any> | void {
-    const msg: any = { type: "select", param: { filter } };
+    const msg: any = { type: "select", param: filter };
     if (context) {
       msg.context = context;
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- send select filter object directly as the `param` payload

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68aa4aeeae588325ad94b9952e18d6fd