### PR TITLE
Unsubscribe endpoints on unload

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -528,7 +528,19 @@ class GiraEndpointAdapter extends utils.Adapter {
         try {
             this.log.info("Shutting down...");
             this.client?.removeAllListeners();
-            this.client?.close();
+            if (this.client) {
+                try {
+                    this.client.unsubscribe(this.endpointKeys);
+                    const states = await this.getStatesAsync("info.subscriptions.*");
+                    for (const id of Object.keys(states)) {
+                        await this.setStateAsync(id, { val: false, ack: true });
+                    }
+                }
+                catch (err) {
+                    this.log.error(`Unsubscribe failed: ${err}`);
+                }
+                this.client.close();
+            }
         }
         catch (e) {
             this.log.error(`onUnload error: ${e}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -540,7 +540,18 @@ class GiraEndpointAdapter extends utils.Adapter {
     try {
       this.log.info("Shutting down...");
       this.client?.removeAllListeners();
-      this.client?.close();
+      if (this.client) {
+        try {
+          this.client.unsubscribe(this.endpointKeys);
+          const states = await this.getStatesAsync("info.subscriptions.*");
+          for (const id of Object.keys(states)) {
+            await this.setStateAsync(id, { val: false, ack: true });
+          }
+        } catch (err) {
+          this.log.error(`Unsubscribe failed: ${err}`);
+        }
+        this.client.close();
+      }
     } catch (e) {
       this.log.error(`onUnload error: ${e}`);
     } finally {


### PR DESCRIPTION
## Summary
- unsubscribe from endpoint keys before closing the client
- reset local subscription states and log errors if unsubscribe fails

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68aa4da2c5088325986560dad27b6b42