### PR TITLE
feat: organize CO@ endpoints into channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Wenn er dir gefällt oder dir weiterhilft, freue ich mich über eine kleine Spen
 
 ## Changelog
 
+### 0.2.3
+* Align CO@ endpoint folder structure with DA@ and move subscription status into each endpoint
+
 ### 0.2.2
 * Fix sending adapter states without "CO@" prefix to the HomeServer
 * Warning - Subscription failed for CO@..., Also ad info.subscriptions

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,12 @@
 {
   "common": {
     "name": "gira-endpoint",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "news": {
+      "0.2.3": {
+        "en": "Align CO@ endpoint structure with DA@ and move subscription status into each endpoint",
+        "de": "CO@ Ordnerstruktur an DA@ angeglichen und Abo-Status in den jeweiligen Endpunkt verschoben"
+      },
       "0.2.2": {
         "en": "Fix sending adapter states without prefix to HomeServer, Allow disabling initial update per endpoint on adapter start, Add Warning - Subscription failed for CO@..., Also ad info.subscriptions",
         "de": "Adapter-eigene States wurden ohne Prefix an den HomeServer gesendet, Initiale Aktualisierung pro Endpunkt beim Start deaktivierbar, Warnung hinzugefügt wenn ein CO@ nicht Abonniert weden kann. Den Abo Status sieht man auch unter info.subscriptions"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "ioBroker adapter for Gira endpoint (WS/WSS) – emits events as states, minimal viable replacement for Node-RED Gira node",
   "author": "you",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
## Summary
- model each CO@ endpoint as a channel with value, subscription, status and meta states
- automatically populate endpoint folders with all provided data fields and handle subscription status per endpoint
- clean up legacy `info.subscriptions` states

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install` *(fails: 403 Forbidden for @iobroker/testing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab568319ac8325b39cbb089e0ae073