### PR TITLE
fix: preserve numeric values for Gira HS

### DIFF
--- a/src/lib/GiraClient.ts
+++ b/src/lib/GiraClient.ts
@@ -269,8 +269,6 @@ export class GiraClient extends EventEmitter {
         }
       }
     }
-    if (v === 1 || v === "1") v = true;
-    else if (v === 0 || v === "0") v = false;
     return v;
   }
 


### PR DESCRIPTION
## Summary
- keep numeric 0/1 values intact during normalization to avoid unwanted boolean conversion

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*


------
https://chatgpt.com/codex/tasks/task_e_68ab68f4b7388325adbc5dfb4e53dd2e