### PR TITLE
fix: handle nested CO@ keys

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -853,7 +853,9 @@ class GiraEndpointAdapter extends utils.Adapter {
         if (parts[parts.length - 1] !== "value")
             return;
         const baseId = parts.slice(0, parts.length - 1).join(".");
-        const key = this.idKeyMap.get(baseId) ?? this.normalizeKey(parts[1]);
+        const key =
+            this.idKeyMap.get(baseId) ??
+            this.normalizeKey(parts.slice(1, parts.length - 1).join("."));
         const boolKey = this.boolKeys.has(key);
         const { uidValue, ackVal, method } = encodeUidValue(state.val, boolKey);
         this.client.call(key, method, uidValue);

--- a/src/main.ts
+++ b/src/main.ts
@@ -859,7 +859,9 @@ class GiraEndpointAdapter extends utils.Adapter {
     const parts = id.split(".");
     if (parts[parts.length - 1] !== "value") return;
     const baseId = parts.slice(0, parts.length - 1).join(".");
-    const key = this.idKeyMap.get(baseId) ?? this.normalizeKey(parts[1]);
+    const key =
+      this.idKeyMap.get(baseId) ??
+      this.normalizeKey(parts.slice(1, parts.length - 1).join("."));
     const boolKey = this.boolKeys.has(key);
     const { uidValue, ackVal, method } = encodeUidValue(state.val, boolKey);
     this.client.call(key, method, uidValue);


### PR DESCRIPTION
## Summary
- ensure direct `CO@` state updates use full key path, not just the first segment

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install` *(fails: 403 Forbidden for @iobroker/testing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6b24f370832597fb68c7fc1772e1