### PR TITLE
Handle fully qualified state IDs before forwarding to HS

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -768,6 +768,11 @@ class GiraEndpointAdapter extends utils.Adapter {
     onStateChange(id, state) {
         if (!state || !this.client)
             return;
+        // In case we receive a fully qualified id (e.g. from setForeignState),
+        // strip the adapter namespace so further processing works as expected.
+        if (id.startsWith(this.namespace + ".")) {
+            id = id.substring(this.namespace.length + 1);
+        }
         const mapped = this.forwardMap.get(id);
         if (mapped) {
             if (this.suppressStateChange.has(id)) {
@@ -853,8 +858,7 @@ class GiraEndpointAdapter extends utils.Adapter {
         if (parts[parts.length - 1] !== "value")
             return;
         const baseId = parts.slice(0, parts.length - 1).join(".");
-        const key =
-            this.idKeyMap.get(baseId) ??
+        const key = this.idKeyMap.get(baseId) ??
             this.normalizeKey(parts.slice(1, parts.length - 1).join("."));
         const boolKey = this.boolKeys.has(key);
         const { uidValue, ackVal, method } = encodeUidValue(state.val, boolKey);

--- a/src/main.ts
+++ b/src/main.ts
@@ -781,6 +781,12 @@ class GiraEndpointAdapter extends utils.Adapter {
   private onStateChange(id: string, state: ioBroker.State | null | undefined): void {
     if (!state || !this.client) return;
 
+    // In case we receive a fully qualified id (e.g. from setForeignState),
+    // strip the adapter namespace so further processing works as expected.
+    if (id.startsWith(this.namespace + ".")) {
+      id = id.substring(this.namespace.length + 1);
+    }
+
     const mapped = this.forwardMap.get(id);
     if (mapped) {
       if (this.suppressStateChange.has(id)) {


### PR DESCRIPTION
## Summary
- Strip adapter namespace from fully qualified ids before processing state changes

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@iobroker%2ftesting)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6c80f0f48325a833291c2de8499e