### PR TITLE
Ignore meta/status events to prevent stray endpoint folders

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -498,6 +498,12 @@ class GiraEndpointAdapter extends utils.Adapter {
                 const data = payload?.data;
                 if (!data)
                     return;
+                const tag = payload?.tag;
+                if (typeof tag === "string" &&
+                    (tag.startsWith("meta_") || tag.startsWith("status_"))) {
+                    // Responses for meta/status calls are handled separately
+                    return;
+                }
                 if (payload.type === "unsubscribe" && Array.isArray(data.items)) {
                     for (const item of data.items) {
                         if (!item)

--- a/src/main.ts
+++ b/src/main.ts
@@ -505,6 +505,15 @@ class GiraEndpointAdapter extends utils.Adapter {
         const data = payload?.data;
         if (!data) return;
 
+        const tag = payload?.tag;
+        if (
+          typeof tag === "string" &&
+          (tag.startsWith("meta_") || tag.startsWith("status_"))
+        ) {
+          // Responses for meta/status calls are handled separately
+          return;
+        }
+
         if (payload.type === "unsubscribe" && Array.isArray((data as any).items)) {
           for (const item of (data as any).items) {
             if (!item) continue;


### PR DESCRIPTION
## Summary
- Ignore websocket events tagged as `meta_` or `status_` so metadata responses aren't treated as standalone endpoints

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@iobroker%2ftesting)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7074e2c4832592b0a2ef9fbe0f0a