### PR TITLE
fix: ignore non-endpoint meta fields

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -643,6 +643,10 @@ class GiraEndpointAdapter extends utils.Adapter {
                     }
                     else {
                         for (const [key, val] of Object.entries(data)) {
+                            if (!key.includes("@")) {
+                                this.log.debug(`Ignoring property ${key} without @`);
+                                continue;
+                            }
                             const obj = typeof val === "object" && val !== null ? val : { value: val };
                             entries.push({ key, data: obj });
                         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -649,6 +649,10 @@ class GiraEndpointAdapter extends utils.Adapter {
             entries.push({ key, data: value });
           } else {
             for (const [key, val] of Object.entries(data)) {
+              if (!key.includes("@")) {
+                this.log.debug(`Ignoring property ${key} without @`);
+                continue;
+              }
               const obj = typeof val === "object" && val !== null ? val : { value: val };
               entries.push({ key, data: obj });
             }


### PR DESCRIPTION
## Summary
- skip object entries without `@` when mapping events to endpoint states
- prevent stray top-level metadata folders

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68ab72be34c88325b2325a5f8c6a6eeb