### PR TITLE
Fix metadata handling for dynamic Gira endpoint keys

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -682,6 +682,33 @@ class GiraEndpointAdapter extends utils.Adapter {
                         common: { name },
                         native: {},
                     });
+                    // Ensure standard states exist for dynamically discovered keys
+                    const subId = `${baseId}.subscription`;
+                    await this.extendObjectAsync(subId, {
+                        type: "state",
+                        common: {
+                            name: "subscription",
+                            type: "boolean",
+                            role: "indicator",
+                            read: true,
+                            write: false,
+                        },
+                        native: {},
+                    });
+                    await this.setStateAsync(subId, { val: true, ack: true });
+                    await this.extendObjectAsync(`${baseId}.status`, {
+                        type: "state",
+                        common: { name: "status", type: "string", role: "state", read: true, write: true },
+                        native: {},
+                    });
+                    await this.extendObjectAsync(`${baseId}.meta`, {
+                        type: "state",
+                        common: { name: "meta", type: "string", role: "json", read: true, write: true },
+                        native: {},
+                    });
+                    this.subscribeStates(`${baseId}.value`);
+                    this.subscribeStates(`${baseId}.meta`);
+                    this.subscribeStates(`${baseId}.status`);
                     if (!this.fetchedMeta.has(normalized)) {
                         this.fetchedMeta.add(normalized);
                         this.fetchMetaStatus(normalized, baseId);

--- a/src/main.ts
+++ b/src/main.ts
@@ -697,6 +697,34 @@ class GiraEndpointAdapter extends utils.Adapter {
             native: {},
           });
 
+          // Ensure standard states exist for dynamically discovered keys
+          const subId = `${baseId}.subscription`;
+          await this.extendObjectAsync(subId, {
+            type: "state",
+            common: {
+              name: "subscription",
+              type: "boolean",
+              role: "indicator",
+              read: true,
+              write: false,
+            },
+            native: {},
+          });
+          await this.setStateAsync(subId, { val: true, ack: true });
+          await this.extendObjectAsync(`${baseId}.status`, {
+            type: "state",
+            common: { name: "status", type: "string", role: "state", read: true, write: true },
+            native: {},
+          });
+          await this.extendObjectAsync(`${baseId}.meta`, {
+            type: "state",
+            common: { name: "meta", type: "string", role: "json", read: true, write: true },
+            native: {},
+          });
+          this.subscribeStates(`${baseId}.value`);
+          this.subscribeStates(`${baseId}.meta`);
+          this.subscribeStates(`${baseId}.status`);
+
           if (!this.fetchedMeta.has(normalized)) {
             this.fetchedMeta.add(normalized);
             this.fetchMetaStatus(normalized, baseId);


### PR DESCRIPTION
## Summary
- Ensure dynamically discovered endpoint keys create meta/status/subscription states
- Subscribe to new meta/status states and set subscription default

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68ab76ebe5588325a122052bc353d351