### PR TITLE
fix: handle subscription errors

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -696,7 +696,13 @@ class GiraEndpointAdapter extends utils.Adapter {
                         },
                         native: {},
                     });
-                    await this.setStateAsync(subId, { val: true, ack: true });
+                    const success = code === undefined || code === 0;
+                    await this.setStateAsync(subId, { val: success, ack: true });
+                    if (!success) {
+                        const msg = `Subscription failed for ${normalized}${code !== undefined ? ` (${code})` : ""}`;
+                        this.log.warn(msg);
+                        this.notifyAdmin(msg);
+                    }
                     await this.extendObjectAsync(`${baseId}.status`, {
                         type: "state",
                         common: { name: "status", type: "string", role: "state", read: true, write: false },

--- a/src/main.ts
+++ b/src/main.ts
@@ -709,7 +709,13 @@ class GiraEndpointAdapter extends utils.Adapter {
             },
             native: {},
           });
-          await this.setStateAsync(subId, { val: true, ack: true });
+          const success = code === undefined || code === 0;
+          await this.setStateAsync(subId, { val: success, ack: true });
+          if (!success) {
+            const msg = `Subscription failed for ${normalized}${code !== undefined ? ` (${code})` : ""}`;
+            this.log.warn(msg);
+            this.notifyAdmin(msg);
+          }
           await this.extendObjectAsync(`${baseId}.status`, {
             type: "state",
             common: { name: "status", type: "string", role: "state", read: true, write: false },


### PR DESCRIPTION
## Summary
- ensure subscription state is false when subscription fails and warn

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68abec43f2688325a988322eae884636