### PR TITLE
Add i18n entries for status codes

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -30,5 +30,14 @@
   "Datenarchive": "Datenarchive",
   "Liste der Homeserver Datenarchiv IDs die abgerufen werden": "Liste der Homeserver Datenarchiv IDs die abgerufen werden",
   "Hier die Datenarchiv IDs ohne das DA@ eintragen": "Hier die Datenarchiv IDs ohne das DA@ eintragen",
-  "DA@": "DA@"
+  "DA@": "DA@",
+  "Alles in Ordnung.": "Alles in Ordnung.",
+  "Ungültige Anfrage (Forbidden).": "Ungültige Anfrage (Forbidden).",
+  "Zugriff verweigert (Bad Request).": "Zugriff verweigert (Bad Request).",
+  "Das angefragte HS-Objekt existiert in dem aufgerufenen Kontext nicht.": "Das angefragte HS-Objekt existiert in dem aufgerufenen Kontext nicht.",
+  "Beim Erzeugen der Antwort ist im Server ein Fehler aufgetreten.": "Beim Erzeugen der Antwort ist im Server ein Fehler aufgetreten.",
+  "Der angegebene Schlüssel ist ungültig.": "Der angegebene Schlüssel ist ungültig.",
+  "reserviert": "reserviert",
+  "Die Objekt-Parameter sind ungültig.": "Die Objekt-Parameter sind ungültig.",
+  "Das Objekt ist nicht abonniert.": "Das Objekt ist nicht abonniert."
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -30,5 +30,14 @@
   "Datenarchive": "Data archives",
   "Liste der Homeserver Datenarchiv IDs die abgerufen werden": "List of home server data archive IDs to fetch",
   "Hier die Datenarchiv IDs ohne das DA@ eintragen": "Enter data archive IDs without the DA@",
-  "DA@": "DA@"
+  "DA@": "DA@",
+  "Alles in Ordnung.": "Everything is fine.",
+  "Ungültige Anfrage (Forbidden).": "Invalid request (Forbidden).",
+  "Zugriff verweigert (Bad Request).": "Access denied (Bad Request).",
+  "Das angefragte HS-Objekt existiert in dem aufgerufenen Kontext nicht.": "The requested HS object does not exist in the invoked context.",
+  "Beim Erzeugen der Antwort ist im Server ein Fehler aufgetreten.": "An error occurred in the server while generating the response.",
+  "Der angegebene Schlüssel ist ungültig.": "The specified key is invalid.",
+  "reserviert": "reserved",
+  "Die Objekt-Parameter sind ungültig.": "The object parameters are invalid.",
+  "Das Objekt ist nicht abonniert.": "The object is not subscribed."
 }

--- a/build/main.js
+++ b/build/main.js
@@ -536,8 +536,11 @@ class GiraEndpointAdapter extends utils.Adapter {
                             native: {},
                         });
                         await this.setStateAsync(subId, { val: false, ack: true });
-                        const statusText = (0, GiraClient_1.codeToMessage)(item.code ?? payload.code ?? 0);
-                        await this.setStateAsync(`${baseId}.status`, { val: statusText, ack: true });
+                        const statusText = this.translate((0, GiraClient_1.codeToMessage)(item.code ?? payload.code ?? 0));
+                        await this.setStateAsync(`${baseId}.status`, {
+                            val: statusText,
+                            ack: true,
+                        });
                         if (item.code !== undefined && item.code !== 0) {
                             const msg = `Unsubscribe failed for ${normalized} (${item.code})`;
                             this.log.warn(msg);
@@ -719,8 +722,11 @@ class GiraEndpointAdapter extends utils.Adapter {
                         this.fetchedMeta.add(normalized);
                         this.fetchMeta(normalized, baseId);
                     }
-                    const statusText = (0, GiraClient_1.codeToMessage)(code ?? payload.code ?? 0);
-                    await this.setStateAsync(`${baseId}.status`, { val: statusText, ack: true });
+                    const statusText = this.translate((0, GiraClient_1.codeToMessage)(code ?? payload.code ?? 0));
+                    await this.setStateAsync(`${baseId}.status`, {
+                        val: statusText,
+                        ack: true,
+                    });
                     for (const [prop, raw] of Object.entries(data)) {
                         const isValue = prop === "value";
                         let val = raw;

--- a/src/main.ts
+++ b/src/main.ts
@@ -543,8 +543,13 @@ class GiraEndpointAdapter extends utils.Adapter {
               native: {},
             });
             await this.setStateAsync(subId, { val: false, ack: true });
-            const statusText = codeToMessage(item.code ?? payload.code ?? 0);
-            await this.setStateAsync(`${baseId}.status`, { val: statusText, ack: true });
+            const statusText = this.translate(
+              codeToMessage(item.code ?? payload.code ?? 0)
+            );
+            await this.setStateAsync(`${baseId}.status`, {
+              val: statusText,
+              ack: true,
+            });
             if (item.code !== undefined && item.code !== 0) {
               const msg = `Unsubscribe failed for ${normalized} (${item.code})`;
               this.log.warn(msg);
@@ -734,8 +739,13 @@ class GiraEndpointAdapter extends utils.Adapter {
             this.fetchMeta(normalized, baseId);
           }
 
-          const statusText = codeToMessage(code ?? payload.code ?? 0);
-          await this.setStateAsync(`${baseId}.status`, { val: statusText, ack: true });
+          const statusText = this.translate(
+            codeToMessage(code ?? payload.code ?? 0)
+          );
+          await this.setStateAsync(`${baseId}.status`, {
+            val: statusText,
+            ack: true,
+          });
 
           for (const [prop, raw] of Object.entries(data)) {
             const isValue = prop === "value";


### PR DESCRIPTION
## Summary
- localize status code messages and store them in status states
- add English translations for new status code messages

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `tsc -p .` *(fails: Cannot find module 'crypto' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68abee319f8483258742ea4c7ea244af