### PR TITLE
fix: guard translation usage

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -536,7 +536,8 @@ class GiraEndpointAdapter extends utils.Adapter {
                             native: {},
                         });
                         await this.setStateAsync(subId, { val: false, ack: true });
-                        const statusText = this.translate((0, GiraClient_1.codeToMessage)(item.code ?? payload.code ?? 0));
+                        const message = (0, GiraClient_1.codeToMessage)(item.code ?? payload.code ?? 0);
+                        const statusText = typeof this.translate === "function" ? this.translate(message) : message;
                         await this.setStateAsync(`${baseId}.status`, {
                             val: statusText,
                             ack: true,
@@ -722,7 +723,8 @@ class GiraEndpointAdapter extends utils.Adapter {
                         this.fetchedMeta.add(normalized);
                         this.fetchMeta(normalized, baseId);
                     }
-                    const statusText = this.translate((0, GiraClient_1.codeToMessage)(code ?? payload.code ?? 0));
+                    const message = (0, GiraClient_1.codeToMessage)(code ?? payload.code ?? 0);
+                    const statusText = typeof this.translate === "function" ? this.translate(message) : message;
                     await this.setStateAsync(`${baseId}.status`, {
                         val: statusText,
                         ack: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -543,9 +543,11 @@ class GiraEndpointAdapter extends utils.Adapter {
               native: {},
             });
             await this.setStateAsync(subId, { val: false, ack: true });
-            const statusText = this.translate(
-              codeToMessage(item.code ?? payload.code ?? 0)
-            );
+            const message = codeToMessage(item.code ?? payload.code ?? 0);
+            const statusText =
+              typeof this.translate === "function"
+                ? this.translate(message)
+                : message;
             await this.setStateAsync(`${baseId}.status`, {
               val: statusText,
               ack: true,
@@ -739,9 +741,11 @@ class GiraEndpointAdapter extends utils.Adapter {
             this.fetchMeta(normalized, baseId);
           }
 
-          const statusText = this.translate(
-            codeToMessage(code ?? payload.code ?? 0)
-          );
+          const message = codeToMessage(code ?? payload.code ?? 0);
+          const statusText =
+            typeof this.translate === "function"
+              ? this.translate(message)
+              : message;
           await this.setStateAsync(`${baseId}.status`, {
             val: statusText,
             ack: true,


### PR DESCRIPTION
## Summary
- avoid crashes when `this.translate` is undefined by falling back to original message

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*


------
https://chatgpt.com/codex/tasks/task_e_68abf028756c8325b3119f048f52f050