### PR TITLE
Fix translation fallback for gira-endpoint adapter

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -38,6 +38,7 @@ exports.decodeAckValue = decodeAckValue;
 const utils = __importStar(require("@iobroker/adapter-core"));
 const GiraClient_1 = require("./lib/GiraClient");
 const crypto_1 = require("crypto");
+const util_1 = require("util");
 function encodeUidValue(val, boolMode) {
     let method = "set";
     let uidValue = val;
@@ -138,6 +139,13 @@ class GiraEndpointAdapter extends utils.Adapter {
         this.archiveIdKeyMap = new Map();
         this.archiveDescMap = new Map();
         this.fetchedMeta = new Set();
+        const origTranslate = this.translate;
+        this.translate = (text, ...args) => {
+            if (typeof origTranslate === "function") {
+                return origTranslate.call(this, text, ...args);
+            }
+            return args.length ? (0, util_1.format)(text, ...args) : text;
+        };
         this.on("ready", this.onReady.bind(this));
         this.on("unload", this.onUnload.bind(this));
         this.on("stateChange", this.onStateChange.bind(this));

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import * as utils from "@iobroker/adapter-core";
 import { GiraClient, codeToMessage } from "./lib/GiraClient";
 import { randomUUID } from "crypto";
+import { format } from "util";
 
 // Configuration options provided by ioBroker's admin interface
 // (extend as needed when more options are supported)
@@ -133,6 +134,16 @@ class GiraEndpointAdapter extends utils.Adapter {
       ...options,
       name: "gira-endpoint",
     });
+    const origTranslate = (this as any).translate;
+    (this as any).translate = (
+      text: string,
+      ...args: any[]
+    ): string => {
+      if (typeof origTranslate === "function") {
+        return origTranslate.call(this, text, ...args);
+      }
+      return args.length ? format(text, ...args) : text;
+    };
     this.on("ready", this.onReady.bind(this));
     this.on("unload", this.onUnload.bind(this));
     this.on("stateChange", this.onStateChange.bind(this));

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,1 +1,7 @@
 declare module "https-proxy-agent";
+declare module "crypto" {
+  export function randomUUID(): string;
+}
+declare module "util" {
+  export function format(fmt: string, ...args: any[]): string;
+}


### PR DESCRIPTION
## Summary
- add runtime fallback when `this.translate` is unavailable
- stub node modules for TypeScript build

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68abffdd10a4832587a5466c08b3e8d4