### PR TITLE
Avoid duplicate logs on failed subscriptions

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -655,9 +655,11 @@ class GiraEndpointAdapter extends utils.Adapter {
                         });
                         await this.setStateAsync(subId, { val: success, ack: true });
                         if (!success) {
-                            const msg = this.translate("Subscription failed for %s", normalized);
+                            const msg = this.translate("Subscription failed for %s", normalized) +
+                                (item.code !== undefined ? ` (${item.code})` : "");
                             this.log.warn(msg);
                             this.notifyAdmin(msg);
+                            continue;
                         }
                         const value = item.data ?? { value: item.value };
                         entries.push({ key, data: value, code: item.code });

--- a/src/main.ts
+++ b/src/main.ts
@@ -690,9 +690,12 @@ class GiraEndpointAdapter extends utils.Adapter {
             });
             await this.setStateAsync(subId, { val: success, ack: true });
             if (!success) {
-              const msg = this.translate("Subscription failed for %s", normalized);
+              const msg =
+                this.translate("Subscription failed for %s", normalized) +
+                (item.code !== undefined ? ` (${item.code})` : "");
               this.log.warn(msg);
               this.notifyAdmin(msg);
+              continue;
             }
             const value = item.data ?? { value: item.value };
             entries.push({ key, data: value, code: item.code });


### PR DESCRIPTION
## Summary
- log failed subscription responses only once and skip further processing
- stop triggering meta calls for invalid endpoints

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install` *(fails: 403 Forbidden for @iobroker/testing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac03f1813883259601de50a2492d22