### PR TITLE
Use concise OK status message

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -31,7 +31,7 @@
   "Liste der Homeserver Datenarchiv IDs die abgerufen werden": "Liste der Homeserver Datenarchiv IDs die abgerufen werden",
   "Hier die Datenarchiv IDs ohne das DA@ eintragen": "Hier die Datenarchiv IDs ohne das DA@ eintragen",
   "DA@": "DA@",
-  "Alles in Ordnung.": "Alles in Ordnung.",
+  "Ok": "Ok",
   "Ungültige Anfrage (Forbidden).": "Ungültige Anfrage (Forbidden).",
   "Zugriff verweigert (Bad Request).": "Zugriff verweigert (Bad Request).",
   "Das angefragte HS-Objekt existiert in dem aufgerufenen Kontext nicht.": "Das angefragte HS-Objekt existiert in dem aufgerufenen Kontext nicht.",

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -31,7 +31,7 @@
   "Liste der Homeserver Datenarchiv IDs die abgerufen werden": "List of home server data archive IDs to fetch",
   "Hier die Datenarchiv IDs ohne das DA@ eintragen": "Enter data archive IDs without the DA@",
   "DA@": "DA@",
-  "Alles in Ordnung.": "Everything is fine.",
+  "Ok": "Ok",
   "Ungültige Anfrage (Forbidden).": "Invalid request (Forbidden).",
   "Zugriff verweigert (Bad Request).": "Access denied (Bad Request).",
   "Das angefragte HS-Objekt existiert in dem aufgerufenen Kontext nicht.": "The requested HS object does not exist in the invoked context.",

--- a/build/lib/GiraClient.js
+++ b/build/lib/GiraClient.js
@@ -12,7 +12,7 @@ events_1.EventEmitter.defaultMaxListeners = 0;
 const BACKOFF_FACTOR = 1.7;
 const BACKOFF_JITTER = 0.2;
 const STATUS_CODE_MESSAGES = {
-    0: "Alles in Ordnung.",
+    0: "Ok",
     400: "Ungültige Anfrage (Forbidden).",
     403: "Zugriff verweigert (Bad Request).",
     404: "Das angefragte HS-Objekt existiert in dem aufgerufenen Kontext nicht.",

--- a/src/lib/GiraClient.ts
+++ b/src/lib/GiraClient.ts
@@ -8,7 +8,7 @@ const BACKOFF_FACTOR = 1.7;
 const BACKOFF_JITTER = 0.2;
 
 const STATUS_CODE_MESSAGES: Record<number, string> = {
-  0: "Alles in Ordnung.",
+  0: "Ok",
   400: "Ungültige Anfrage (Forbidden).",
   403: "Zugriff verweigert (Bad Request).",
   404: "Das angefragte HS-Objekt existiert in dem aufgerufenen Kontext nicht.",


### PR DESCRIPTION
## Summary
- replace verbose status message "Alles in Ordnung." with "Ok"
- update admin translations to match the new status text

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing')*


------
https://chatgpt.com/codex/tasks/task_e_68ac0e43a3108325ac7e935638e7d7b6