### PR TITLE
Add auth header toggle

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -39,8 +39,7 @@
   "Der angegebene Schlüssel ist ungültig.": "Der angegebene Schlüssel ist ungültig.",
   "reserviert": "reserviert",
   "Die Objekt-Parameter sind ungültig.": "Die Objekt-Parameter sind ungültig.",
-  "Das Objekt ist nicht abonniert.": "Das Objekt ist nicht abonniert."
-,
+  "Das Objekt ist nicht abonniert.": "Das Objekt ist nicht abonniert.",
   "Info": "Info",
   "Connection": "Verbindung",
   "Last error": "Letzter Fehler",
@@ -83,5 +82,6 @@
   "onUnload error: %s": "Fehler in onUnload: %s",
   "Ignoring state change for %s because it was just updated from endpoint": "Ignoriere Zustandsänderung für %s, da sie gerade vom Endpoint aktualisiert wurde",
   "Invalid query parameters for %s: %s": "Ungültige Abfrageparameter für %s: %s",
-  "Get call failed for %s: %s": "Get-Aufruf fehlgeschlagen für %s: %s"
+  "Get call failed for %s: %s": "Get-Aufruf fehlgeschlagen für %s: %s",
+  "Auth-Header verwenden": "Auth-Header verwenden"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -39,8 +39,7 @@
   "Der angegebene Schlüssel ist ungültig.": "The specified key is invalid.",
   "reserviert": "reserved",
   "Die Objekt-Parameter sind ungültig.": "The object parameters are invalid.",
-  "Das Objekt ist nicht abonniert.": "The object is not subscribed."
-,
+  "Das Objekt ist nicht abonniert.": "The object is not subscribed.",
   "Info": "Info",
   "Connection": "Connection",
   "Last error": "Last error",
@@ -83,5 +82,6 @@
   "onUnload error: %s": "onUnload error: %s",
   "Ignoring state change for %s because it was just updated from endpoint": "Ignoring state change for %s because it was just updated from endpoint",
   "Invalid query parameters for %s: %s": "Invalid query parameters for %s: %s",
-  "Get call failed for %s: %s": "Get call failed for %s: %s"
+  "Get call failed for %s: %s": "Get call failed for %s: %s",
+  "Auth-Header verwenden": "Use auth header"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -40,7 +40,7 @@
           "lg": 4,
           "xl": 4
         },
-        "authHeader": {
+        "authHeaderHeader": {
           "type": "header",
           "text": "Authentifizierung",
           "size": 2
@@ -57,6 +57,16 @@
         "password": {
           "type": "password",
           "label": "Passwort",
+          "xs": 12,
+          "sm": 6,
+          "md": 6,
+          "lg": 4,
+          "xl": 4
+        },
+        "authHeader": {
+          "type": "checkbox",
+          "label": "Auth-Header verwenden",
+          "default": false,
           "xs": 12,
           "sm": 6,
           "md": 6,

--- a/io-package.json
+++ b/io-package.json
@@ -56,6 +56,7 @@
     "ssl": false,
     "username": "",
     "password": "",
+    "authHeader": false,
     "pingIntervalMs": 30000,
     "reconnect": {
       "minMs": 1000,


### PR DESCRIPTION
## Summary
- add checkbox to enable Basic Auth header
- include translations and native default

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing'; npm install forbidden 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac13371ff48325ba5d2f88d1d97042