### PR TITLE
Rename server field and placeholder

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -1,8 +1,8 @@
 {
   "Einstellungen": "Einstellungen",
   "Gira Endpoint Verbindung": "Gira Endpoint Verbindung",
-  "Host": "Host",
-  "192.168.x.y": "192.168.x.y",
+  "Gira Server": "Gira Server",
+  "IP oder FQDN": "IP oder FQDN",
   "Port": "Port",
   "TLS (wss://) aktivieren": "TLS (wss://) aktivieren",
   "Authentifizierung": "Authentifizierung",

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -1,8 +1,8 @@
 {
   "Einstellungen": "Settings",
   "Gira Endpoint Verbindung": "Gira endpoint connection",
-  "Host": "Host",
-  "192.168.x.y": "192.168.x.y",
+  "Gira Server": "Gira server",
+  "IP or FQDN": "IP or FQDN",
   "Port": "Port",
   "TLS (wss://) aktivieren": "Enable TLS (wss://)",
   "Authentifizierung": "Authentication",

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -12,8 +12,8 @@
         },
         "host": {
           "type": "text",
-          "label": "Host",
-          "placeholder": "192.168.x.y",
+          "label": "Gira Server",
+          "placeholder": "IP or FQDN",
           "xs": 12,
           "sm": 6,
           "md": 6,


### PR DESCRIPTION
## Summary
- rename server setting to "Gira Server"
- clarify placeholder to accept IP or FQDN

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@iobroker%2ftesting)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4e872d98832589f15fe4079d18f8