### PR TITLE
feat(admin): group mappings in accordion

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -186,55 +186,83 @@
           "size": 2
         },
         "mappings": {
-          "type": "table",
+          "type": "accordion",
           "label": "Hier die Endpunkt IDs und ioBroker Objekte eintragen",
-          "style": {
-            "fontSize": "0.8rem"
-          },
-          "xs": 12,
-          "sm": 12,
-          "md": 12,
-          "lg": 12,
-          "xl": 12,
+          "titleAttr": "key",
           "items": [
             {
               "type": "text",
               "attr": "stateId",
-              "label": "State ID"
+              "label": "State ID",
+              "xs": 12,
+              "sm": 12,
+              "md": 6,
+              "lg": 6,
+              "xl": 6
             },
             {
               "type": "text",
               "attr": "key",
-              "label": "CO@"
+              "label": "CO@",
+              "xs": 12,
+              "sm": 12,
+              "md": 6,
+              "lg": 6,
+              "xl": 6
             },
             {
               "type": "text",
               "attr": "name",
-              "label": "Beschreibung"
+              "label": "Beschreibung",
+              "xs": 12,
+              "sm": 12,
+              "md": 6,
+              "lg": 6,
+              "xl": 6
             },
             {
               "type": "checkbox",
               "attr": "toEndpoint",
               "label": "ioBroker → Endpunkt",
-              "default": true
+              "default": true,
+              "xs": 12,
+              "sm": 6,
+              "md": 4,
+              "lg": 4,
+              "xl": 4
             },
             {
               "type": "checkbox",
               "attr": "toState",
               "label": "Endpunkt → ioBroker",
-              "default": false
+              "default": false,
+              "xs": 12,
+              "sm": 6,
+              "md": 4,
+              "lg": 4,
+              "xl": 4
             },
             {
               "type": "checkbox",
               "attr": "bool",
               "label": "0/1 ↔ true/false",
-              "default": false
+              "default": false,
+              "xs": 12,
+              "sm": 6,
+              "md": 4,
+              "lg": 4,
+              "xl": 4
             },
             {
               "type": "checkbox",
               "attr": "updateOnStart",
               "label": "Beim Start aktualisieren",
-              "default": true
+              "default": true,
+              "xs": 12,
+              "sm": 6,
+              "md": 4,
+              "lg": 4,
+              "xl": 4
             }
           ]
         }

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,12 @@
 {
   "common": {
     "name": "gira-endpoint",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "news": {
+      "0.2.4": {
+        "en": "Use accordion for mapping endpoints in admin UI",
+        "de": "Mapping-Endpunkte in der Admin-Oberfläche als Akkordeon umgesetzt"
+      },
       "0.2.3": {
         "en": "Align CO@ endpoint structure with DA@ and move subscription status into each endpoint",
         "de": "CO@ Ordnerstruktur an DA@ angeglichen und Abo-Status in den jeweiligen Endpunkt verschoben"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "ioBroker adapter for Gira endpoint (WS/WSS) – emits events as states, minimal viable replacement for Node-RED Gira node",
   "author": "you",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
## Summary
- use accordion to allow collapsible mapping endpoints in admin UI
- bump version to 0.2.4

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@iobroker%2ftesting)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0572f6fc8325b90093ca11f5a36b