### PR TITLE
feat(admin): group mapping endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Eingabewerte können sein:  true | false | toggle | String | Number
 - `String` und `Number` → werden direkt durchgereicht
 -  Bei den Mapping Endpunkten kann ein ioBroker Objekt (z.B. 0_userdata.0.mappingtest) eines anderen Adapters angegeben werden, das dann zum HS in das angegebene KO (CO@) durchgereicht wird.
    Hier kann die Richtung per Checkbos ausgewählt werden falls eine Richtung nicht bedient werden soll.
+   Mehrere Zuordnungen lassen sich in der Admin-Oberfläche in Gruppen bündeln.
 
 ## Homeserver konfigurieren
 

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -185,56 +185,102 @@
           "text": "Liste der Homeserver Endpunkt IDs die abonniert werden und zusätzlich in einen anderes ioBroker Objekt geschrieben / von dort gelesen werden",
           "size": 2
         },
-        "mappings": {
-          "type": "table",
+        "mappingGroups": {
+          "type": "accordion",
           "label": "Hier die Endpunkt IDs und ioBroker Objekte eintragen",
-          "style": {
-            "fontSize": "0.8rem"
-          },
-          "xs": 12,
-          "sm": 12,
-          "md": 12,
-          "lg": 12,
-          "xl": 12,
+          "titleAttr": "group",
           "items": [
             {
               "type": "text",
-              "attr": "stateId",
-              "label": "State ID"
+              "attr": "group",
+              "label": "Gruppe",
+              "xs": 12,
+              "sm": 12,
+              "md": 6,
+              "lg": 6,
+              "xl": 6
             },
             {
-              "type": "text",
-              "attr": "key",
-              "label": "CO@"
-            },
-            {
-              "type": "text",
-              "attr": "name",
-              "label": "Beschreibung"
-            },
-            {
-              "type": "checkbox",
-              "attr": "toEndpoint",
-              "label": "ioBroker → Endpunkt",
-              "default": true
-            },
-            {
-              "type": "checkbox",
-              "attr": "toState",
-              "label": "Endpunkt → ioBroker",
-              "default": false
-            },
-            {
-              "type": "checkbox",
-              "attr": "bool",
-              "label": "0/1 ↔ true/false",
-              "default": false
-            },
-            {
-              "type": "checkbox",
-              "attr": "updateOnStart",
-              "label": "Beim Start aktualisieren",
-              "default": true
+              "newLine": true,
+              "type": "accordion",
+              "attr": "mappings",
+              "titleAttr": "key",
+              "items": [
+                {
+                  "type": "text",
+                  "attr": "stateId",
+                  "label": "State ID",
+                  "xs": 12,
+                  "sm": 12,
+                  "md": 6,
+                  "lg": 6,
+                  "xl": 6
+                },
+                {
+                  "type": "text",
+                  "attr": "key",
+                  "label": "CO@",
+                  "xs": 12,
+                  "sm": 12,
+                  "md": 6,
+                  "lg": 6,
+                  "xl": 6
+                },
+                {
+                  "type": "text",
+                  "attr": "name",
+                  "label": "Beschreibung",
+                  "xs": 12,
+                  "sm": 12,
+                  "md": 6,
+                  "lg": 6,
+                  "xl": 6
+                },
+                {
+                  "type": "checkbox",
+                  "attr": "toEndpoint",
+                  "label": "ioBroker → Endpunkt",
+                  "default": true,
+                  "xs": 12,
+                  "sm": 6,
+                  "md": 4,
+                  "lg": 4,
+                  "xl": 4
+                },
+                {
+                  "type": "checkbox",
+                  "attr": "toState",
+                  "label": "Endpunkt → ioBroker",
+                  "default": false,
+                  "xs": 12,
+                  "sm": 6,
+                  "md": 4,
+                  "lg": 4,
+                  "xl": 4
+                },
+                {
+                  "type": "checkbox",
+                  "attr": "bool",
+                  "label": "0/1 ↔ true/false",
+                  "default": false,
+                  "xs": 12,
+                  "sm": 6,
+                  "md": 4,
+                  "lg": 4,
+                  "xl": 4
+                },
+                {
+                  "type": "checkbox",
+                  "attr": "updateOnStart",
+                  "label": "Beim Start aktualisieren",
+                  "default": true,
+                  "xs": 12,
+                  "sm": 6,
+                  "md": 4,
+                  "lg": 4,
+                  "xl": 4
+                }
+              ]
             }
           ]
         }

--- a/build/main.js
+++ b/build/main.js
@@ -251,8 +251,18 @@ class GiraEndpointAdapter extends utils.Adapter {
             }
             const forwardMap = new Map();
             const reverseMap = new Map();
-            if (Array.isArray(cfg.mappings)) {
-                for (const m of cfg.mappings) {
+            const mappingGroups = Array.isArray(cfg.mappingGroups)
+                ? cfg.mappingGroups
+                : Array.isArray(cfg.mappings)
+                    ? [{ mappings: cfg.mappings }]
+                    : [];
+            for (const g of mappingGroups) {
+                if (!g || typeof g !== "object")
+                    continue;
+                const list = g.mappings;
+                if (!Array.isArray(list))
+                    continue;
+                for (const m of list) {
                     if (typeof m !== "object" || !m)
                         continue;
                     const stateId = String(m.stateId ?? "").trim();

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,16 @@
 {
   "common": {
     "name": "gira-endpoint",
-    "version": "0.2.3",
+    "version": "0.2.5",
     "news": {
+      "0.2.5": {
+        "en": "Group mapping endpoints in accordion",
+        "de": "Mapping-Endpunkte in Gruppen innerhalb eines Akkordeons zusammenfassen"
+      },
+      "0.2.4": {
+        "en": "Use accordion for mapping endpoints in admin UI",
+        "de": "Mapping-Endpunkte in der Admin-Oberfläche als Akkordeon umgesetzt"
+      },
       "0.2.3": {
         "en": "Align CO@ endpoint structure with DA@ and move subscription status into each endpoint",
         "de": "CO@ Ordnerstruktur an DA@ angeglichen und Abo-Status in den jeweiligen Endpunkt verschoben"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.2.2",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.gira-endpoint",
-      "version": "0.2.2",
+      "version": "0.2.5",
       "license": "GPL-3.0",
       "dependencies": {
-        "@iobroker/adapter-core": "^3.1.0",
+        "@iobroker/adapter-core": "^3.2.2",
         "ws": "^8.18.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "description": "ioBroker adapter for Gira endpoint (WS/WSS) – emits events as states, minimal viable replacement for Node-RED Gira node",
   "author": "you",
   "license": "GPL-3.0-or-later",

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,18 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
     toState?: boolean;
     bool?: boolean;
     updateOnStart?: boolean;
+  }[]; // legacy support
+  mappingGroups?: {
+    group?: string;
+    mappings: {
+      stateId: string;
+      key: string;
+      name?: string;
+      toEndpoint?: boolean;
+      toState?: boolean;
+      bool?: boolean;
+      updateOnStart?: boolean;
+    }[];
   }[];
   dataArchives?:
     | string[]
@@ -258,8 +270,16 @@ class GiraEndpointAdapter extends utils.Adapter {
 
       const forwardMap = new Map<string, { key: string; bool: boolean }>();
       const reverseMap = new Map<string, { stateId: string; bool: boolean }>();
-      if (Array.isArray(cfg.mappings)) {
-        for (const m of cfg.mappings) {
+      const mappingGroups = Array.isArray(cfg.mappingGroups)
+        ? cfg.mappingGroups
+        : Array.isArray(cfg.mappings)
+        ? [{ mappings: cfg.mappings }]
+        : [];
+      for (const g of mappingGroups) {
+        if (!g || typeof g !== "object") continue;
+        const list = (g as any).mappings;
+        if (!Array.isArray(list)) continue;
+        for (const m of list) {
           if (typeof m !== "object" || !m) continue;
           const stateId = String((m as any).stateId ?? "").trim();
           const key = this.normalizeKey(String((m as any).key ?? "").trim());


### PR DESCRIPTION
## Summary
- support organizing mapping endpoints into nested accordion groups in admin UI
- handle grouped mappings at runtime and document the feature

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68ae0572f6fc8325b90093ca11f5a36b