### PR TITLE
feat: group simple endpoints

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -139,23 +139,15 @@
           "text": "Liste der Homeserver Endpunkt IDs die abonniert werden",
           "size": 2
         },
-        "endpointKeys": {
+        "endpointGroups": {
           "type": "accordion",
-          "label": "Hier die Endpunkt IDs ohne das CO@ eintragen",
-          "titleAttr": "key",
-          "style": {
-            "fontSize": "0.7rem"
-          },
-          "xs": 12,
-          "sm": 12,
-          "md": 12,
-          "lg": 12,
-          "xl": 12,
+          "label": "Hier Gruppen erstellen und die Endpunkt IDs eintragen",
+          "titleAttr": "group",
           "items": [
             {
               "type": "text",
-              "attr": "key",
-              "label": "CO@",
+              "attr": "group",
+              "label": "Gruppenname",
               "xs": 12,
               "sm": 12,
               "md": 6,
@@ -163,36 +155,57 @@
               "xl": 6
             },
             {
-              "type": "text",
-              "attr": "name",
-              "label": "Beschreibung",
-              "xs": 12,
-              "sm": 12,
-              "md": 6,
-              "lg": 6,
-              "xl": 6
-            },
-            {
-              "type": "checkbox",
-              "attr": "bool",
-              "label": "0/1 ↔ true/false",
-              "default": false,
-              "xs": 12,
-              "sm": 6,
-              "md": 4,
-              "lg": 4,
-              "xl": 4
-            },
-            {
-              "type": "checkbox",
-              "attr": "updateOnStart",
-              "label": "Beim Start aktualisieren",
-              "default": true,
-              "xs": 12,
-              "sm": 6,
-              "md": 4,
-              "lg": 4,
-              "xl": 4
+              "newLine": true,
+              "type": "accordion",
+              "attr": "keys",
+              "titleAttr": "key",
+              "style": {
+                "fontSize": "0.7rem"
+              },
+              "items": [
+                {
+                  "type": "text",
+                  "attr": "key",
+                  "label": "CO@",
+                  "xs": 12,
+                  "sm": 12,
+                  "md": 6,
+                  "lg": 6,
+                  "xl": 6
+                },
+                {
+                  "type": "text",
+                  "attr": "name",
+                  "label": "Beschreibung",
+                  "xs": 12,
+                  "sm": 12,
+                  "md": 6,
+                  "lg": 6,
+                  "xl": 6
+                },
+                {
+                  "type": "checkbox",
+                  "attr": "bool",
+                  "label": "0/1 ↔ true/false",
+                  "default": false,
+                  "xs": 12,
+                  "sm": 6,
+                  "md": 4,
+                  "lg": 4,
+                  "xl": 4
+                },
+                {
+                  "type": "checkbox",
+                  "attr": "updateOnStart",
+                  "label": "Beim Start aktualisieren",
+                  "default": true,
+                  "xs": 12,
+                  "sm": 6,
+                  "md": 4,
+                  "lg": 4,
+                  "xl": 4
+                }
+              ]
             }
           ]
         }

--- a/build/main.js
+++ b/build/main.js
@@ -214,7 +214,9 @@ class GiraEndpointAdapter extends utils.Adapter {
             const pingIntervalMs = Number(cfg.pingIntervalMs ?? 30000);
             const boolKeys = new Set();
             const skipInitial = new Set();
-            const rawKeys = cfg.endpointKeys;
+            const rawKeys = Array.isArray(cfg.endpointGroups)
+                ? cfg.endpointGroups.flatMap((g) => Array.isArray(g?.keys) ? g.keys : [])
+                : cfg.endpointKeys;
             const endpointKeys = [];
             if (Array.isArray(rawKeys)) {
                 for (const k of rawKeys) {

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,12 @@
 {
   "common": {
     "name": "gira-endpoint",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "news": {
+      "0.2.6": {
+        "en": "Group simple endpoints in accordion",
+        "de": "Einfache Endpunkte in Gruppen innerhalb eines Akkordeons zusammenfassen"
+      },
       "0.2.5": {
         "en": "Group mapping endpoints in accordion",
         "de": "Mapping-Endpunkte in Gruppen innerhalb eines Akkordeons zusammenfassen"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "ioBroker adapter for Gira endpoint (WS/WSS) – emits events as states, minimal viable replacement for Node-RED Gira node",
   "author": "you",
   "license": "GPL-3.0-or-later",

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,15 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
     | string[]
     | { key: string; name?: string; bool?: boolean; updateOnStart?: boolean }[]
     | string;
+  endpointGroups?: {
+    group?: string;
+    keys: {
+      key: string;
+      name?: string;
+      bool?: boolean;
+      updateOnStart?: boolean;
+    }[];
+  }[];
   updateLastEvent?: boolean;
   mappings?: {
     stateId: string;
@@ -239,7 +248,11 @@ class GiraEndpointAdapter extends utils.Adapter {
       const boolKeys = new Set<string>();
       const skipInitial = new Set<string>();
 
-      const rawKeys = cfg.endpointKeys;
+      const rawKeys = Array.isArray(cfg.endpointGroups)
+        ? cfg.endpointGroups.flatMap((g: any) =>
+            Array.isArray(g?.keys) ? g.keys : []
+          )
+        : cfg.endpointKeys;
       const endpointKeys: string[] = [];
       if (Array.isArray(rawKeys)) {
         for (const k of rawKeys) {


### PR DESCRIPTION
## Summary
- group simple endpoint configuration using nested accordions
- parse endpointGroups in adapter
- bump version to 0.2.6

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing')*


------
https://chatgpt.com/codex/tasks/task_e_68ae24625df48325b2fcb0e000172e4f