### PR TITLE
fix: remove unsupported style settings from admin tables

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -141,9 +141,6 @@
         "endpointKeys": {
           "type": "table",
           "label": "Hier die Endpunkt IDs ohne das CO@ eintragen",
-          "style": {
-            "fontSize": "0.8rem"
-          },
           "xs": 12,
           "sm": 12,
           "md": 12,
@@ -188,9 +185,6 @@
         "mappings": {
           "type": "table",
           "label": "Hier die Endpunkt IDs und ioBroker Objekte eintragen",
-          "style": {
-            "fontSize": "0.8rem"
-          },
           "xs": 12,
           "sm": 12,
           "md": 12,
@@ -252,9 +246,6 @@
         "dataArchives": {
           "type": "table",
           "label": "Hier die Datenarchiv IDs ohne das DA@ eintragen",
-          "style": {
-            "fontSize": "0.8rem"
-          },
           "xs": 12,
           "sm": 12,
           "md": 12,


### PR DESCRIPTION
## Summary
- remove style property from JSON config tables to satisfy schema

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@iobroker%2ftesting)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2c8521b08325a13c6e3f53c06b91