### PR TITLE
Remove unsupported style entries from jsonConfig

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -1,6 +1,5 @@
 {
   "type": "tabs",
-  "style": { "fontSize": "14px" },
   "items": {
     "settingsTab": {
       "type": "panel",
@@ -159,9 +158,6 @@
               "type": "accordion",
               "attr": "keys",
               "titleAttr": "key",
-              "style": {
-                "fontSize": "0.7rem"
-              },
               "items": [
                 {
                   "type": "text",
@@ -333,9 +329,6 @@
         "dataArchives": {
           "type": "table",
           "label": "Hier die Datenarchiv IDs ohne das DA@ eintragen",
-          "style": {
-            "fontSize": "0.7rem"
-          },
           "xs": 12,
           "sm": 12,
           "md": 12,


### PR DESCRIPTION
## Summary
- remove style attributes from admin/jsonConfig.json to comply with ioBroker schema

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@iobroker%2ftesting)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2e69293883259f6b25f99f3fd6a7