### PR TITLE
Add enabled toggle for CO@ and DA@ entries

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -87,5 +87,6 @@
   "Ignoring state change for %s because it was just updated from endpoint": "Ignoriere Zustandsänderung für %s, da sie gerade vom Endpoint aktualisiert wurde",
   "Invalid query parameters for %s: %s": "Ungültige Abfrageparameter für %s: %s",
   "Get call failed for %s: %s": "Get-Aufruf fehlgeschlagen für %s: %s",
+  "Aktiviert": "Aktiviert",
   "Auth-Header verwenden": "Auth-Header verwenden"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -87,5 +87,6 @@
   "Ignoring state change for %s because it was just updated from endpoint": "Ignoring state change for %s because it was just updated from endpoint",
   "Invalid query parameters for %s: %s": "Invalid query parameters for %s: %s",
   "Get call failed for %s: %s": "Get call failed for %s: %s",
+  "Aktiviert": "Enabled",
   "Auth-Header verwenden": "Use auth header"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -181,6 +181,17 @@
                 },
                 {
                   "type": "checkbox",
+                  "attr": "enabled",
+                  "label": "Aktiviert",
+                  "default": true,
+                  "xs": 12,
+                  "sm": 6,
+                  "md": 4,
+                  "lg": 4,
+                  "xl": 4
+                },
+                {
+                  "type": "checkbox",
                   "attr": "bool",
                   "label": "0/1 ↔ true/false",
                   "default": false,
@@ -269,6 +280,17 @@
                 },
                 {
                   "type": "checkbox",
+                  "attr": "enabled",
+                  "label": "Aktiviert",
+                  "default": true,
+                  "xs": 12,
+                  "sm": 6,
+                  "md": 4,
+                  "lg": 4,
+                  "xl": 4
+                },
+                {
+                  "type": "checkbox",
                   "attr": "toEndpoint",
                   "label": "ioBroker → Endpunkt",
                   "default": true,
@@ -344,6 +366,12 @@
               "type": "text",
               "attr": "name",
               "label": "Beschreibung"
+            },
+            {
+              "type": "checkbox",
+              "attr": "enabled",
+              "label": "Aktiviert",
+              "default": true
             },
             {
               "type": "text",

--- a/build/main.js
+++ b/build/main.js
@@ -221,6 +221,8 @@ class GiraEndpointAdapter extends utils.Adapter {
             if (Array.isArray(rawKeys)) {
                 for (const k of rawKeys) {
                     if (typeof k === "object" && k) {
+                        if (k.enabled === false)
+                            continue;
                         const key = this.normalizeKey(String(k.key ?? "").trim());
                         if (!key)
                             continue;
@@ -267,6 +269,8 @@ class GiraEndpointAdapter extends utils.Adapter {
                 for (const m of list) {
                     if (typeof m !== "object" || !m)
                         continue;
+                    if (m.enabled === false)
+                        continue;
                     const stateId = String(m.stateId ?? "").trim();
                     const key = this.normalizeKey(String(m.key ?? "").trim());
                     if (!stateId || !key)
@@ -304,6 +308,8 @@ class GiraEndpointAdapter extends utils.Adapter {
             if (Array.isArray(rawArchives)) {
                 for (const a of rawArchives) {
                     if (typeof a === "object" && a) {
+                        if (a.enabled === false)
+                            continue;
                         const key = this.normalizeArchiveKey(String(a.key ?? "").trim());
                         if (!key)
                             continue;

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,13 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
   rejectUnauthorized?: boolean;
   endpointKeys?:
     | string[]
-    | { key: string; name?: string; bool?: boolean; updateOnStart?: boolean }[]
+    | {
+        key: string;
+        name?: string;
+        bool?: boolean;
+        updateOnStart?: boolean;
+        enabled?: boolean;
+      }[]
     | string;
   endpointGroups?: {
     group?: string;
@@ -29,6 +35,7 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
       name?: string;
       bool?: boolean;
       updateOnStart?: boolean;
+      enabled?: boolean;
     }[];
   }[];
   updateLastEvent?: boolean;
@@ -40,6 +47,7 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
     toState?: boolean;
     bool?: boolean;
     updateOnStart?: boolean;
+    enabled?: boolean;
   }[]; // legacy support
   mappingGroups?: {
     group?: string;
@@ -51,6 +59,7 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
       toState?: boolean;
       bool?: boolean;
       updateOnStart?: boolean;
+      enabled?: boolean;
     }[];
   }[];
   dataArchives?:
@@ -61,6 +70,7 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
         start?: string;
         end?: string;
         columns?: string[] | string;
+        enabled?: boolean;
       }[]
     | string;
 }
@@ -257,6 +267,7 @@ class GiraEndpointAdapter extends utils.Adapter {
       if (Array.isArray(rawKeys)) {
         for (const k of rawKeys) {
           if (typeof k === "object" && k) {
+            if ((k as any).enabled === false) continue;
             const key = this.normalizeKey(String((k as any).key ?? "").trim());
             if (!key) continue;
             const name = String((k as any).name ?? "").trim();
@@ -294,6 +305,7 @@ class GiraEndpointAdapter extends utils.Adapter {
         if (!Array.isArray(list)) continue;
         for (const m of list) {
           if (typeof m !== "object" || !m) continue;
+          if ((m as any).enabled === false) continue;
           const stateId = String((m as any).stateId ?? "").trim();
           const key = this.normalizeKey(String((m as any).key ?? "").trim());
           if (!stateId || !key) continue;
@@ -325,6 +337,7 @@ class GiraEndpointAdapter extends utils.Adapter {
       if (Array.isArray(rawArchives)) {
         for (const a of rawArchives) {
           if (typeof a === "object" && a) {
+            if ((a as any).enabled === false) continue;
             const key = this.normalizeArchiveKey(String((a as any).key ?? "").trim());
             if (!key) continue;
             const name = String((a as any).name ?? "").trim();


### PR DESCRIPTION
## Summary
- add `Aktiviert` checkbox to CO@ and DA@ configuration entries
- skip disabled entries during endpoint and archive setup

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68b1688038bc8325b7fd5a65df53866c