### PR TITLE
Add confirmed flag for mapping endpoints

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -88,5 +88,6 @@
   "Invalid query parameters for %s: %s": "Ungültige Abfrageparameter für %s: %s",
   "Get call failed for %s: %s": "Get-Aufruf fehlgeschlagen für %s: %s",
   "Aktiviert": "Aktiviert",
+  "Bestätigt": "Bestätigt",
   "Auth-Header verwenden": "Auth-Header verwenden"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -88,5 +88,6 @@
   "Invalid query parameters for %s: %s": "Invalid query parameters for %s: %s",
   "Get call failed for %s: %s": "Get call failed for %s: %s",
   "Aktiviert": "Enabled",
+  "Bestätigt": "Confirmed",
   "Auth-Header verwenden": "Use auth header"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -313,6 +313,17 @@
                 },
                 {
                   "type": "checkbox",
+                  "attr": "ack",
+                  "label": "Bestätigt",
+                  "default": true,
+                  "xs": 12,
+                  "sm": 6,
+                  "md": 4,
+                  "lg": 4,
+                  "xl": 4
+                },
+                {
+                  "type": "checkbox",
                   "attr": "bool",
                   "label": "0/1 ↔ true/false",
                   "default": false,

--- a/build/main.js
+++ b/build/main.js
@@ -281,6 +281,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                     const toEndpoint = m.toEndpoint !== false;
                     const toState = Boolean(m.toState);
                     const bool = Boolean(m.bool);
+                    const ack = m.ack !== false;
                     const updateOnStart = m.updateOnStart !== false;
                     if (!updateOnStart)
                         skipInitial.add(key);
@@ -290,7 +291,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                             boolKeys.add(key);
                     }
                     if (toState) {
-                        reverseMap.set(key, { stateId, bool });
+                        reverseMap.set(key, { stateId, bool, ack });
                         if (bool)
                             boolKeys.add(key);
                     }
@@ -935,7 +936,10 @@ class GiraEndpointAdapter extends utils.Adapter {
                                 let mappedVal = decodeAckValue(val, mappedForeign.bool).value;
                                 this.log.debug(this.translate("Updating mapped foreign state %s -> %s", mappedForeign.stateId, JSON.stringify(mappedVal)));
                                 this.suppressStateChange.add(mappedForeign.stateId);
-                                await this.setForeignStateAsync(mappedForeign.stateId, { val: mappedVal, ack: true });
+                                await this.setForeignStateAsync(mappedForeign.stateId, {
+                                    val: mappedVal,
+                                    ack: mappedForeign.ack,
+                                });
                                 const timer = this.setTimeout(() => {
                                     this.suppressStateChange.delete(mappedForeign.stateId);
                                     this.clearTimeout(timer);
@@ -1168,7 +1172,10 @@ class GiraEndpointAdapter extends utils.Adapter {
             let mappedVal = decodeAckValue(ackVal, mappedForeign.bool).value;
             this.log.debug(`Updating mapped foreign state ${mappedForeign.stateId} -> ${JSON.stringify(mappedVal)}`);
             this.suppressStateChange.add(mappedForeign.stateId);
-            this.setForeignState(mappedForeign.stateId, { val: mappedVal, ack: true });
+            this.setForeignState(mappedForeign.stateId, {
+                val: mappedVal,
+                ack: mappedForeign.ack,
+            });
             const timer = this.setTimeout(() => {
                 this.suppressStateChange.delete(mappedForeign.stateId);
                 this.clearTimeout(timer);


### PR DESCRIPTION
## Summary
- add "Bestätigt" checkbox to mapping endpoints
- allow mapping values to write ack flag in ioBroker states

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install --no-audit @iobroker/testing` *(fails: ENOTEMPTY: directory not empty)*

------
https://chatgpt.com/codex/tasks/task_e_68b36667744883259297703dffc2ac88