### PR TITLE
Preserve skipInitialUpdate across reconnects

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -133,6 +133,7 @@ class GiraEndpointAdapter extends utils.Adapter {
         this.suppressStateChange = new Set();
         this.pendingUpdates = new Map();
         this.skipInitialUpdate = new Set();
+        this.initialSkipUpdate = new Set();
         this.pendingSubscriptions = new Set();
         this.archiveKeys = [];
         this.archiveKeyIdMap = new Map();
@@ -303,6 +304,7 @@ class GiraEndpointAdapter extends utils.Adapter {
             this.reverseMap = reverseMap;
             this.boolKeys = boolKeys;
             this.skipInitialUpdate = skipInitial;
+            this.initialSkipUpdate = new Set(skipInitial);
             this.archiveQueryDefaults.clear();
             const rawArchives = cfg.dataArchives;
             const archiveKeys = [];
@@ -564,6 +566,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                 this.log.info(this.translate("Connected to %s", url));
                 this.setState("info.connection", true, true);
                 this.fetchedMeta.clear();
+                this.skipInitialUpdate = new Set(this.initialSkipUpdate);
                 if (this.endpointKeys.length) {
                     this.pendingSubscriptions = new Set(this.endpointKeys.map((k) => this.normalizeKey(k)));
                     this.client.subscribe(this.endpointKeys);

--- a/src/main.ts
+++ b/src/main.ts
@@ -154,6 +154,7 @@ class GiraEndpointAdapter extends utils.Adapter {
   private suppressStateChange = new Set<string>();
   private pendingUpdates = new Map<string, any>();
   private skipInitialUpdate = new Set<string>();
+  private initialSkipUpdate = new Set<string>();
   private pendingSubscriptions = new Set<string>();
   private archiveKeys: string[] = [];
   private archiveKeyIdMap = new Map<string, string>();
@@ -334,6 +335,7 @@ class GiraEndpointAdapter extends utils.Adapter {
       this.reverseMap = reverseMap;
       this.boolKeys = boolKeys;
       this.skipInitialUpdate = skipInitial;
+      this.initialSkipUpdate = new Set(skipInitial);
       this.archiveQueryDefaults.clear();
       const rawArchives = cfg.dataArchives;
       const archiveKeys: string[] = [];
@@ -614,6 +616,7 @@ class GiraEndpointAdapter extends utils.Adapter {
         this.log.info(this.translate("Connected to %s", url));
         this.setState("info.connection", true, true);
         this.fetchedMeta.clear();
+        this.skipInitialUpdate = new Set(this.initialSkipUpdate);
         if (this.endpointKeys.length) {
           this.pendingSubscriptions = new Set(
             this.endpointKeys.map((k) => this.normalizeKey(k))


### PR DESCRIPTION
## Summary
- Maintain a persistent set of keys that skip initial updates
- Repopulate skipInitialUpdate from the persistent copy after config parsing
- Reset skipInitialUpdate on every connection open to skip first events again

## Testing
- `npm run build`
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm start` *(fails: Cannot find module '@iobroker/adapter-core')*


------
https://chatgpt.com/codex/tasks/task_e_68b53c1702708325873f211b2b3dc3a3