### PR TITLE
chore: update changelog and bump version to 0.2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ So lassen sich Schaltzustände, Sensorwerte oder Szenen aus dem Gira-System naht
 - Konfigurierbare Mappings zwischen beliebigen ioBroker States und Gira-Endpunkten, wahlweise in beide Richtungen
 - Optionale 0/1 ↔ true/false-Umwandlung pro Mapping -> so wird aus einem 0/1 vom HS ein False / True für andere Zwecke
 - Initiale Aktualisierung beim Adapterstart pro Endpunkt einzeln deaktivierbar
+- Deaktivierte Initialaktualisierung bleibt auch nach Verbindungsabbrüchen erhalten
 
 ### Usage
 Eingabewerte können sein:  true | false | toggle | String | Number
@@ -81,6 +82,18 @@ Wenn er dir gefällt oder dir weiterhilft, freue ich mich über eine kleine Spen
 [GPLv3](LICENSE)
 
 ## Changelog
+
+### 0.2.7
+* Preserve skipInitialUpdate across reconnects
+
+### 0.2.6
+* Group simple endpoints in accordion
+
+### 0.2.5
+* Group mapping endpoints in accordion
+
+### 0.2.4
+* Use accordion for mapping endpoints in admin UI
 
 ### 0.2.3
 * Align CO@ endpoint folder structure with DA@ and move subscription status into each endpoint

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,12 @@
 {
   "common": {
     "name": "gira-endpoint",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "news": {
+      "0.2.7": {
+        "en": "Preserve skipInitialUpdate across reconnects",
+        "de": "Speichert skipInitialUpdate über Verbindungsabbrüche hinweg"
+      },
       "0.2.6": {
         "en": "Group simple endpoints in accordion",
         "de": "Einfache Endpunkte in Gruppen innerhalb eines Akkordeons zusammenfassen"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.2.5",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.gira-endpoint",
-      "version": "0.2.5",
+      "version": "0.2.7",
       "license": "GPL-3.0",
       "dependencies": {
         "@iobroker/adapter-core": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "ioBroker adapter for Gira endpoint (WS/WSS) – emits events as states, minimal viable replacement for Node-RED Gira node",
   "author": "you",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
## Summary
- document skipped initial updates persisting across reconnects
- add recent release notes and bump version to 0.2.7

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*
- `npm install` *(fails: 403 Forbidden @iobroker/testing)*

------
https://chatgpt.com/codex/tasks/task_e_68b5495ed4e883258b0899d5da15c811