### PR TITLE
feat(admin): allow selecting state for mapping endpoints

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -25,7 +25,7 @@
   "Liste der Homeserver Endpunkt IDs die abonniert werden und zusätzlich in einen anderes ioBroker Objekt geschrieben / von dort gelesen werden": "Liste der Homeserver Endpunkt IDs die abonniert werden und zusätzlich in einen anderes ioBroker Objekt geschrieben / von dort gelesen werden",
   "Hier Gruppen erstellen und die Endpunkt IDs und ioBroker Objekte eintragen": "Hier Gruppen erstellen und die Endpunkt IDs und ioBroker Objekte eintragen",
   "Gruppenname": "Gruppenname",
-  "State ID": "State ID",
+  "Objekt": "Objekt",
   "ioBroker → Endpunkt": "ioBroker → Endpunkt",
   "Endpunkt → ioBroker": "Endpunkt → ioBroker",
   "Datenarchive": "Datenarchive",

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -25,7 +25,7 @@
   "Liste der Homeserver Endpunkt IDs die abonniert werden und zusätzlich in einen anderes ioBroker Objekt geschrieben / von dort gelesen werden": "List of home server endpoint IDs to subscribe and additionally write to/read from other ioBroker objects",
   "Hier Gruppen erstellen und die Endpunkt IDs und ioBroker Objekte eintragen": "Create groups here and enter the endpoint IDs and ioBroker objects",
   "Gruppenname": "Group name",
-  "State ID": "State ID",
+  "Objekt": "Object",
   "ioBroker → Endpunkt": "ioBroker → Endpoint",
   "Endpunkt → ioBroker": "Endpoint → ioBroker",
   "Datenarchive": "Data archives",

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -249,9 +249,9 @@
               "titleAttr": "key",
               "items": [
                 {
-                  "type": "text",
+                  "type": "objectId",
                   "attr": "stateId",
-                  "label": "State ID",
+                  "label": "Objekt",
                   "xs": 12,
                   "sm": 12,
                   "md": 6,


### PR DESCRIPTION
## Summary
- use objectId field so mapping states can be chosen via triple-dot selector

## Testing
- `npm install` (fails: 403 Forbidden for @iobroker/testing)
- `npm test` (fails: Cannot find module '@iobroker/testing`)


------
https://chatgpt.com/codex/tasks/task_e_68bf2c89f5f0832588387372de8bd5a8