### PR TITLE
feat: add validation hints for endpoint fields

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -89,5 +89,8 @@
   "Get call failed for %s: %s": "Get-Aufruf fehlgeschlagen für %s: %s",
   "Aktiviert": "Aktiviert",
   "Bestätigt": "Bestätigt",
+  "ioBroker Objekt": "ioBroker Objekt",
+  "HomeServer Endpunkt CO@": "HomeServer Endpunkt CO@",
+  "Pflichtfeld": "Pflichtfeld",
   "Auth-Header verwenden": "Auth-Header verwenden"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -89,5 +89,8 @@
   "Get call failed for %s: %s": "Get call failed for %s: %s",
   "Aktiviert": "Enabled",
   "Bestätigt": "Confirmed",
+  "ioBroker Objekt": "ioBroker object",
+  "HomeServer Endpunkt CO@": "HomeServer endpoint CO@",
+  "Pflichtfeld": "Required field",
   "Auth-Header verwenden": "Use auth header"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -167,7 +167,11 @@
                   "sm": 12,
                   "md": 6,
                   "lg": 6,
-                  "xl": 6
+                  "xl": 6,
+                  "help": "HomeServer Endpunkt CO@",
+                  "validator": "data.key.length > 0",
+                  "validatorErrorText": "Pflichtfeld",
+                  "validatorNoSaveOnError": true
                 },
                 {
                   "type": "text",
@@ -256,7 +260,11 @@
                   "sm": 12,
                   "md": 6,
                   "lg": 6,
-                  "xl": 6
+                  "xl": 6,
+                  "help": "ioBroker Objekt",
+                  "validator": "data.stateId.length > 0",
+                  "validatorErrorText": "Pflichtfeld",
+                  "validatorNoSaveOnError": true
                 },
                 {
                   "type": "text",
@@ -266,7 +274,11 @@
                   "sm": 12,
                   "md": 6,
                   "lg": 6,
-                  "xl": 6
+                  "xl": 6,
+                  "help": "HomeServer Endpunkt CO@",
+                  "validator": "data.key.length > 0",
+                  "validatorErrorText": "Pflichtfeld",
+                  "validatorNoSaveOnError": true
                 },
                 {
                   "type": "text",


### PR DESCRIPTION
## Summary
- highlight empty CO@ and object fields in endpoint configuration
- clarify field purpose with ioBroker and HomeServer help text

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68bf31cd3c7483258969204f8e442a46