### PR TITLE
Validate group names in admin UI

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -151,7 +151,10 @@
               "sm": 12,
               "md": 6,
               "lg": 6,
-              "xl": 6
+              "xl": 6,
+              "validator": "data.group.length > 0",
+              "validatorErrorText": "Pflichtfeld",
+              "validatorNoSaveOnError": true
             },
             {
               "newLine": true,
@@ -244,7 +247,10 @@
                 "sm": 12,
                 "md": 6,
                 "lg": 6,
-                "xl": 6
+                "xl": 6,
+                "validator": "data.group.length > 0",
+                "validatorErrorText": "Pflichtfeld",
+                "validatorNoSaveOnError": true
               },
             {
               "newLine": true,


### PR DESCRIPTION
## Summary
- ensure group names are not empty in endpoint and mapping configuration

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68bf347932c883259b5f780c11fad96c