### PR TITLE
chore: release 0.2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Wenn er dir gefällt oder dir weiterhilft, freue ich mich über eine kleine Spen
 
 ## Changelog
 
+### 0.2.8
+* Validate group names and show validation hints for endpoint fields in admin UI
+* Add three-dot menu for objects
+
 ### 0.2.7
 * Preserve skipInitialUpdate across reconnects
 

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,12 @@
 {
   "common": {
     "name": "gira-endpoint",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "news": {
+      "0.2.8": {
+        "en": "Validate group names, show validation hints for endpoint fields, and add three-dot menu for objects in admin UI",
+        "de": "Gruppennamen validieren, Validierungshinweise für Endpunktfelder in der Admin-Oberfläche anzeigen und Drei-Punkte-Menü für Objekte hinzufügen"
+      },
       "0.2.7": {
         "en": "Preserve skipInitialUpdate across reconnects",
         "de": "Speichert skipInitialUpdate über Verbindungsabbrüche hinweg"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.gira-endpoint",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "GPL-3.0",
       "dependencies": {
         "@iobroker/adapter-core": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "ioBroker adapter for Gira endpoint (WS/WSS) – emits events as states, minimal viable replacement for Node-RED Gira node",
   "author": "you",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
## Summary
- validate group names and show validation hints for endpoint fields in admin UI
- add three-dot menu for objects in changelog
- bump version to 0.2.8

## Testing
- `npm test` *(fails: Cannot find module '@iobroker/testing')*

------
https://chatgpt.com/codex/tasks/task_e_68bf36b666088325a297f58f31ba2358