### PR TITLE
Add validation for CO@/DA@ fields in admin UI

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -92,5 +92,7 @@
   "ioBroker Objekt": "ioBroker Objekt",
   "HomeServer Endpunkt CO@": "HomeServer Endpunkt CO@",
   "Pflichtfeld": "Pflichtfeld",
+  "Pflichtfeld, ohne führendes CO@": "Pflichtfeld, ohne führendes CO@",
+  "Pflichtfeld, ohne führendes DA@": "Pflichtfeld, ohne führendes DA@",
   "Auth-Header verwenden": "Auth-Header verwenden"
 }

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -92,5 +92,7 @@
   "ioBroker Objekt": "ioBroker object",
   "HomeServer Endpunkt CO@": "HomeServer endpoint CO@",
   "Pflichtfeld": "Required field",
+  "Pflichtfeld, ohne führendes CO@": "Required field, without leading CO@",
+  "Pflichtfeld, ohne führendes DA@": "Required field, without leading DA@",
   "Auth-Header verwenden": "Use auth header"
 }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -172,8 +172,8 @@
                   "lg": 6,
                   "xl": 6,
                   "help": "HomeServer Endpunkt CO@",
-                  "validator": "data.key.length > 0",
-                  "validatorErrorText": "Pflichtfeld",
+                  "validator": "((data.key || '').trim().length > 0) && !((data.key || '').trim().toUpperCase().startsWith('CO@'))",
+                  "validatorErrorText": "Pflichtfeld, ohne führendes CO@",
                   "validatorNoSaveOnError": true
                 },
                 {
@@ -282,8 +282,8 @@
                   "lg": 6,
                   "xl": 6,
                   "help": "HomeServer Endpunkt CO@",
-                  "validator": "data.key.length > 0",
-                  "validatorErrorText": "Pflichtfeld",
+                  "validator": "((data.key || '').trim().length > 0) && !((data.key || '').trim().toUpperCase().startsWith('CO@'))",
+                  "validatorErrorText": "Pflichtfeld, ohne führendes CO@",
                   "validatorNoSaveOnError": true
                 },
                 {
@@ -389,7 +389,10 @@
             {
               "type": "text",
               "attr": "key",
-              "label": "DA@"
+              "label": "DA@",
+              "validator": "((data.key || '').trim().length > 0) && !((data.key || '').trim().toUpperCase().startsWith('DA@'))",
+              "validatorErrorText": "Pflichtfeld, ohne führendes DA@",
+              "validatorNoSaveOnError": true
             },
             {
               "type": "text",


### PR DESCRIPTION
## Summary
- add validation to CO@ endpoint inputs to prevent saving keys with the prefix included
- require data archive keys to be provided without the DA@ prefix and localize the error message

## Testing
- npm test *(fails: missing @iobroker/testing dependency because the registry request was rejected with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfa595edc8325befa85bc4234f78e