### PR TITLE
chore: release 0.2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Wenn er dir gefällt oder dir weiterhilft, freue ich mich über eine kleine Spen
 
 ## Changelog
 
+### 0.2.9
+* Preserve case for CO@ endpoint object IDs
+* Validate CO@/DA@ fields without prefixes in the admin UI
+
 ### 0.2.8
 * Validate group names and show validation hints for endpoint fields in admin UI
 * Add three-dot menu for objects

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,12 @@
 {
   "common": {
     "name": "gira-endpoint",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "news": {
+      "0.2.9": {
+        "en": "Preserve CO@ endpoint object ID casing and validate CO@/DA@ fields without prefixes",
+        "de": "Schreibweise der CO@-Endpunkt-IDs beibehalten und CO@-/DA@-Felder ohne Präfix validieren"
+      },
       "0.2.8": {
         "en": "Validate group names, show validation hints for endpoint fields, and add three-dot menu for objects in admin UI",
         "de": "Gruppennamen validieren, Validierungshinweise für Endpunktfelder in der Admin-Oberfläche anzeigen und Drei-Punkte-Menü für Objekte hinzufügen"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.gira-endpoint",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "GPL-3.0",
       "dependencies": {
         "@iobroker/adapter-core": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "ioBroker adapter for Gira endpoint (WS/WSS) – emits events as states, minimal viable replacement for Node-RED Gira node",
   "author": "you",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
## Summary
- bump the adapter version to 0.2.9
- document the latest admin UI fixes in io-package.json and the README changelog

## Testing
- npm test *(fails: missing @iobroker/testing because the registry request is forbidden in this environment)*
- npm install *(fails: 403 when fetching @iobroker/testing from the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfcade74c8325820adb5a0f8d8040