### PR TITLE
Queue HomeServer restart resend until websocket reconnect

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -158,6 +158,8 @@ class GiraEndpointAdapter extends utils.Adapter {
   private initialSkipUpdate = new Set<string>();
   private updateOnStartSources: Array<{ key: string; stateId: string; bool: boolean; foreign: boolean }> = [];
   private pendingSubscriptions = new Set<string>();
+  private isConnected = false;
+  private pendingHsRestart = false;
   private archiveKeys: string[] = [];
   private archiveKeyIdMap = new Map<string, string>();
   private archiveIdKeyMap = new Map<string, string>();
@@ -670,6 +672,7 @@ class GiraEndpointAdapter extends utils.Adapter {
       this.client.on("open", () => {
         const url = `${ssl ? "wss" : "ws"}://${host}:${port}${path}`;
         this.log.info(this.translate("Connected to %s", url));
+        this.isConnected = true;
         this.setState("info.connection", true, true);
         this.fetchedMeta.clear();
         this.skipInitialUpdate = new Set(this.initialSkipUpdate);
@@ -717,6 +720,10 @@ class GiraEndpointAdapter extends utils.Adapter {
             ack: true,
           });
         }
+        if (this.pendingHsRestart) {
+          this.pendingHsRestart = false;
+          void this.triggerUpdateOnStart();
+        }
       });
 
       this.client.on("close", (info: any) => {
@@ -726,6 +733,7 @@ class GiraEndpointAdapter extends utils.Adapter {
           info?.reason || ""
         );
         this.log.warn(msg);
+        this.isConnected = false;
         this.setState("info.connection", false, true);
         this.getStatesAsync("CO@.*.subscription")
           .then((states: Record<string, ioBroker.State | null>) => {
@@ -1216,7 +1224,8 @@ class GiraEndpointAdapter extends utils.Adapter {
   }
 
   private async triggerUpdateOnStart(): Promise<void> {
-    if (!this.client) {
+    if (!this.client || !this.isConnected) {
+      this.pendingHsRestart = true;
       this.log.warn(
         this.translate(
           "Cannot resend update-on-start values because client is not connected"
@@ -1310,9 +1319,19 @@ class GiraEndpointAdapter extends utils.Adapter {
     if (id === "info.hsRestart") {
       if (state?.ack) return;
       if (state?.val === true) {
-        this.triggerUpdateOnStart().finally(() => {
+        if (!this.isConnected) {
+          this.pendingHsRestart = true;
+          this.log.warn(
+            this.translate(
+              "HomeServer restart trigger queued until connection is restored"
+            )
+          );
           this.setState("info.hsRestart", { val: false, ack: true });
-        });
+        } else {
+          this.triggerUpdateOnStart().finally(() => {
+            this.setState("info.hsRestart", { val: false, ack: true });
+          });
+        }
       } else {
         this.setState("info.hsRestart", { val: !!state?.val, ack: true });
       }


### PR DESCRIPTION
### Motivation
- Resend of `update-on-start` values could be lost when the adapter was offline; setting `info.hsRestart` while disconnected did not trigger the resend until a full adapter restart.

### Description
- Track adapter connection state via a new `isConnected` flag and a `pendingHsRestart` marker in `src/main.ts`.
- When the websocket `open` event fires, set `isConnected = true` and fire any queued HomeServer restart resend by calling `triggerUpdateOnStart()`.
- When the websocket `close` event fires, set `isConnected = false` to prevent attempts to send while disconnected.
- Guard `triggerUpdateOnStart()` to queue the resend when `!this.client || !this.isConnected`, and update `info.hsRestart` handling to queue the restart trigger when offline instead of dropping it.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f54e4201483259c4d0a4e019e0665)