### PR TITLE
Handle common truthy values for HomeServer restart trigger

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1318,7 +1318,9 @@ class GiraEndpointAdapter extends utils.Adapter {
 
     if (id === "info.hsRestart") {
       if (state?.ack) return;
-      if (state?.val === true) {
+      const shouldTrigger =
+        state?.val === true || state?.val === 1 || state?.val === "true";
+      if (shouldTrigger) {
         if (!this.isConnected) {
           this.pendingHsRestart = true;
           this.log.warn(


### PR DESCRIPTION
### Motivation
- The HomeServer restart trigger did not fire when the `info.hsRestart` state was set to non-boolean truthy values (e.g. `1` or the string `"true"`), so the restart flow should accept common truthy representations.

### Description
- Update `onStateChange` handling for `info.hsRestart` in `src/main.ts` to compute `shouldTrigger` as `state?.val === true || state?.val === 1 || state?.val === "true"` instead of a strict `=== true` check, preserving the existing behavior of queuing when disconnected and clearing the trigger after execution.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f57881770832586af5ab5a303cef8)