### PR TITLE
Fix HomeServer restart trigger resync and accept string "1"

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1252,21 +1252,19 @@ class GiraEndpointAdapter extends utils.Adapter {
         this.keyIdMap.set(src.key, baseId);
         this.idKeyMap.set(baseId, src.key);
 
-        if (!src.foreign) {
-          await this.setStateAsync(`${baseId}.value`, { val: ackVal, ack: true });
-          const mappedForeign = this.reverseMap.get(src.key);
-          if (mappedForeign) {
-            const mappedVal = decodeAckValue(ackVal, mappedForeign.bool).value;
-            this.suppressStateChange.add(mappedForeign.stateId);
-            await this.setForeignStateAsync(mappedForeign.stateId, {
-              val: mappedVal,
-              ack: mappedForeign.ack,
-            });
-            const timer = this.setTimeout(() => {
-              this.suppressStateChange.delete(mappedForeign.stateId);
-              this.clearTimeout(timer);
-            }, 1000);
-          }
+        await this.setStateAsync(`${baseId}.value`, { val: ackVal, ack: true });
+        const mappedForeign = this.reverseMap.get(src.key);
+        if (mappedForeign) {
+          const mappedVal = decodeAckValue(ackVal, mappedForeign.bool).value;
+          this.suppressStateChange.add(mappedForeign.stateId);
+          await this.setForeignStateAsync(mappedForeign.stateId, {
+            val: mappedVal,
+            ack: mappedForeign.ack,
+          });
+          const timer = this.setTimeout(() => {
+            this.suppressStateChange.delete(mappedForeign.stateId);
+            this.clearTimeout(timer);
+          }, 1000);
         }
 
         this.pendingUpdates.set(src.key, ackVal);
@@ -1319,7 +1317,10 @@ class GiraEndpointAdapter extends utils.Adapter {
     if (id === "info.hsRestart") {
       if (state?.ack) return;
       const shouldTrigger =
-        state?.val === true || state?.val === 1 || state?.val === "true";
+        state?.val === true ||
+        state?.val === 1 ||
+        state?.val === "true" ||
+        state?.val === "1";
       if (shouldTrigger) {
         if (!this.isConnected) {
           this.pendingHsRestart = true;


### PR DESCRIPTION
### Motivation
- Ensure that when the HomeServer restart trigger is used the adapter always refreshes the configured endpoint state and any reverse-mapped ioBroker state so values are reflected after a restart.
- Accept common representations of a trigger value so `info.hsRestart` works when set to the string `"1"` as well as boolean/number values.

### Description
- Remove the `!src.foreign` guard so the adapter always writes the endpoint `.<base>.value` state during `triggerUpdateOnStart` and continues to update any mapped foreign state via `reverseMap`.
- Keep adding the key into `keyIdMap`/`idKeyMap` and mark pending updates with `pendingUpdates` to preserve existing resend logic.
- Extend the restart trigger condition in `onStateChange` for `info.hsRestart` to treat the string `"1"` as a valid trigger in addition to `true`, `1`, and `"true"`.
- Commit message: `Fix restart trigger state resync`.

### Testing
- No automated tests were executed as part of this change.
- No test failures reported because no tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f5bbbb96c8325940ba36c1d87aaa8)