### PR TITLE
Add debug log for HomeServer restart trigger

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1315,6 +1315,13 @@ class GiraEndpointAdapter extends utils.Adapter {
     }
 
     if (id === "info.hsRestart") {
+      this.log.debug(
+        this.translate(
+          "HomeServer restart trigger received (val=%s, ack=%s)",
+          state?.val,
+          state?.ack
+        )
+      );
       if (state?.ack) return;
       const shouldTrigger =
         state?.val === true ||


### PR DESCRIPTION
### Motivation
- Help diagnose why the HomeServer restart trigger (`info.hsRestart`) is not firing by recording when the trigger state is received and what values it carries.

### Description
- Add a debug log in `onStateChange` for `info.hsRestart` that logs `HomeServer restart trigger received (val=%s, ack=%s)` with `state?.val` and `state?.ack` in `src/main.ts`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f5f3fd9a483258197483577868478)