### PR TITLE
Add `command` channel and unify HomeServer restart trigger handling

### DIFF
--- a/admin/i18n/de/translations.json
+++ b/admin/i18n/de/translations.json
@@ -88,6 +88,7 @@
   "Invalid query parameters for %s: %s": "Ungültige Abfrageparameter für %s: %s",
   "Get call failed for %s: %s": "Get-Aufruf fehlgeschlagen für %s: %s",
   "HomeServer restart trigger": "HomeServer-Neustart auslösen",
+  "Commands": "Befehle",
   "Cannot resend update-on-start values because client is not connected": "Kann Aktualisieren-beim-Start-Werte nicht senden, keine Verbindung zum Client",
   "Resending update-on-start states after HomeServer restart": "Sende Aktualisieren-beim-Start-Werte nach HomeServer-Neustart erneut",
   "Failed to resend update-on-start value for %s: %s": "Aktualisieren-beim-Start-Wert für %s konnte nicht erneut gesendet werden: %s",

--- a/admin/i18n/en/translations.json
+++ b/admin/i18n/en/translations.json
@@ -88,6 +88,7 @@
   "Invalid query parameters for %s: %s": "Invalid query parameters for %s: %s",
   "Get call failed for %s: %s": "Get call failed for %s: %s",
   "HomeServer restart trigger": "HomeServer restart trigger",
+  "Commands": "Commands",
   "Cannot resend update-on-start values because client is not connected": "Cannot resend update-on-start values because client is not connected",
   "Resending update-on-start states after HomeServer restart": "Resending update-on-start states after HomeServer restart",
   "Failed to resend update-on-start value for %s: %s": "Failed to resend update-on-start value for %s: %s",

--- a/src/main.ts
+++ b/src/main.ts
@@ -250,7 +250,25 @@ class GiraEndpointAdapter extends utils.Adapter {
         native: {},
       });
       await this.setStateAsync("info.connection", { val: false, ack: true });
+      await this.setObjectNotExistsAsync("command", {
+        type: "channel",
+        common: { name: this.translate("Commands") },
+        native: {},
+      });
+      await this.setObjectNotExistsAsync("command.hsRestart", {
+        type: "state",
+        common: {
+          name: this.translate("HomeServer restart trigger"),
+          type: "boolean",
+          role: "button",
+          read: true,
+          write: true,
+          def: false,
+        },
+        native: {},
+      });
       this.subscribeStates("info.hsRestart");
+      this.subscribeStates("command.hsRestart");
       this.log.debug(this.translate("Pre-created info states"));
 
       await this.setObjectNotExistsAsync("CO@", {
@@ -1314,37 +1332,8 @@ class GiraEndpointAdapter extends utils.Adapter {
       id = id.substring(this.namespace.length + 1);
     }
 
-    if (id === "info.hsRestart") {
-      this.log.debug(
-        this.translate(
-          "HomeServer restart trigger received (val=%s, ack=%s)",
-          state?.val,
-          state?.ack
-        )
-      );
-      if (state?.ack) return;
-      const shouldTrigger =
-        state?.val === true ||
-        state?.val === 1 ||
-        state?.val === "true" ||
-        state?.val === "1";
-      if (shouldTrigger) {
-        if (!this.isConnected) {
-          this.pendingHsRestart = true;
-          this.log.warn(
-            this.translate(
-              "HomeServer restart trigger queued until connection is restored"
-            )
-          );
-          this.setState("info.hsRestart", { val: false, ack: true });
-        } else {
-          this.triggerUpdateOnStart().finally(() => {
-            this.setState("info.hsRestart", { val: false, ack: true });
-          });
-        }
-      } else {
-        this.setState("info.hsRestart", { val: !!state?.val, ack: true });
-      }
+    if (id === "info.hsRestart" || id === "command.hsRestart") {
+      this.handleHsRestartTrigger(id, state);
       return;
     }
 
@@ -1516,6 +1505,42 @@ class GiraEndpointAdapter extends utils.Adapter {
       this.clearTimeout(timer);
     }, 1000);
     this.setState(id, { val: ackVal, ack: true });
+  }
+
+  private handleHsRestartTrigger(
+    id: "info.hsRestart" | "command.hsRestart",
+    state: ioBroker.State | null | undefined
+  ): void {
+    this.log.debug(
+      this.translate(
+        "HomeServer restart trigger received (val=%s, ack=%s)",
+        state?.val,
+        state?.ack
+      )
+    );
+    if (state?.ack) return;
+    const shouldTrigger =
+      state?.val === true ||
+      state?.val === 1 ||
+      state?.val === "true" ||
+      state?.val === "1";
+    if (shouldTrigger) {
+      if (!this.isConnected) {
+        this.pendingHsRestart = true;
+        this.log.warn(
+          this.translate(
+            "HomeServer restart trigger queued until connection is restored"
+          )
+        );
+        this.setState(id, { val: false, ack: true });
+      } else {
+        this.triggerUpdateOnStart().finally(() => {
+          this.setState(id, { val: false, ack: true });
+        });
+      }
+    } else {
+      this.setState(id, { val: !!state?.val, ack: true });
+    }
   }
 }
 


### PR DESCRIPTION
### Motivation

- Provide a dedicated location for issuing commands (instead of reusing `info`) so restart triggers can be sent without confusing info states.  
- Ensure both the legacy `info.hsRestart` and the new `command.hsRestart` behave identically and reset themselves after processing.

### Description

- Create a new `command` channel and a `command.hsRestart` state with the same properties as `info.hsRestart`.  
- Subscribe to both `info.hsRestart` and `command.hsRestart` and handle them uniformly.  
- Extract restart logic into a new helper `handleHsRestartTrigger` and use it for both state ids.  
- Add the `Commands` translation entry to `admin/i18n/en/translations.json` and `admin/i18n/de/translations.json`.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f66e31580832581e7e3915a5c23e4)