### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,12 @@
 {
   "common": {
     "name": "gira-endpoint",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "news": {
+      "0.3.1": {
+        "en": "Bump version to 0.3.1",
+        "de": "Version auf 0.3.1 erhöht"
+      },
       "0.3.0": {
         "en": "Add HomeServer restart trigger to resend update-on-start values in both directions",
         "de": "Neuen HomeServer-Neustart-Trigger hinzugefügt, um Aktualisieren-beim-Start-Werte in beide Richtungen erneut zu senden"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "ioBroker adapter for Gira endpoint (WS/WSS) – emits events as states, minimal viable replacement for Node-RED Gira node",
   "author": "you",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
### Motivation
- Bump the adapter package version to `0.3.1` to publish the new release.

### Description
- Update `io-package.json` and `package.json`: set version to `0.3.1` and add a `0.3.1` changelog entry in `io-package.json`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f785877048325a58a231112e48186)