### PR TITLE
Remove info restart trigger from build output

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -196,18 +196,6 @@ class GiraEndpointAdapter extends utils.Adapter {
                 },
                 native: {},
             });
-            await this.setObjectNotExistsAsync("info.hsRestart", {
-                type: "state",
-                common: {
-                    name: this.translate("HomeServer restart trigger"),
-                    type: "boolean",
-                    role: "button",
-                    read: true,
-                    write: true,
-                    def: false,
-                },
-                native: {},
-            });
             await this.setStateAsync("info.connection", { val: false, ack: true });
             await this.setObjectNotExistsAsync("command", {
                 type: "channel",
@@ -226,7 +214,6 @@ class GiraEndpointAdapter extends utils.Adapter {
                 },
                 native: {},
             });
-            this.subscribeStates("info.hsRestart");
             this.subscribeStates("command.hsRestart");
             this.log.debug(this.translate("Pre-created info states"));
             await this.setObjectNotExistsAsync("CO@", {


### PR DESCRIPTION
### Motivation
- Avoid creating a duplicate HomeServer restart trigger in the `info` channel so only the command-level trigger is present.

### Description
- Removed creation of the `info.hsRestart` state and the corresponding `subscribeStates("info.hsRestart")` call in `build/main.js`, leaving `command.hsRestart` intact.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f87418d74832597302f83ab2575d9)