### PR TITLE
Add optional Latin1 encoding for endpoint text writes

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -209,6 +209,28 @@
                   "xl": 4
                 },
                 {
+                  "type": "select",
+                  "attr": "textEncoding",
+                  "label": "Text-Encoding",
+                  "default": "utf8",
+                  "options": [
+                    {
+                      "label": "UTF-8",
+                      "value": "utf8"
+                    },
+                    {
+                      "label": "Latin1",
+                      "value": "latin1"
+                    }
+                  ],
+                  "xs": 12,
+                  "sm": 6,
+                  "md": 4,
+                  "lg": 4,
+                  "xl": 4,
+                  "help": "Kodierung für nicht-numerische Texte beim Schreiben zum HomeServer"
+                },
+                {
                   "type": "checkbox",
                   "attr": "updateOnStart",
                   "label": "Beim Start aktualisieren",
@@ -350,6 +372,28 @@
                   "md": 4,
                   "lg": 4,
                   "xl": 4
+                },
+                {
+                  "type": "select",
+                  "attr": "textEncoding",
+                  "label": "Text-Encoding",
+                  "default": "utf8",
+                  "options": [
+                    {
+                      "label": "UTF-8",
+                      "value": "utf8"
+                    },
+                    {
+                      "label": "Latin1",
+                      "value": "latin1"
+                    }
+                  ],
+                  "xs": 12,
+                  "sm": 6,
+                  "md": 4,
+                  "lg": 4,
+                  "xl": 4,
+                  "help": "Kodierung für nicht-numerische Texte beim Schreiben zum HomeServer"
                 },
                 {
                   "type": "checkbox",

--- a/build/main.js
+++ b/build/main.js
@@ -336,7 +336,9 @@ class GiraEndpointAdapter extends utils.Adapter {
                     const bool = Boolean(m.bool);
                     const ack = m.ack !== false;
                     const textEncoding = normalizeTextEncoding(m.textEncoding);
-                    keyTextEncodingMap.set(key, textEncoding);
+                    if (!keyTextEncodingMap.has(key)) {
+                        keyTextEncodingMap.set(key, textEncoding);
+                    }
                     const updateOnStart = m.updateOnStart !== false;
                     if (!updateOnStart)
                         skipInitial.add(key);

--- a/build/main.js
+++ b/build/main.js
@@ -39,7 +39,10 @@ const utils = __importStar(require("@iobroker/adapter-core"));
 const GiraClient_1 = require("./lib/GiraClient");
 const crypto_1 = require("crypto");
 const util_1 = require("util");
-function encodeUidValue(val, boolMode) {
+function normalizeTextEncoding(textEncoding) {
+    return textEncoding === "latin1" ? "latin1" : "utf8";
+}
+function encodeUidValue(val, boolMode, textEncoding = "utf8") {
     let method = "set";
     let uidValue = val;
     let ackVal = val;
@@ -68,7 +71,7 @@ function encodeUidValue(val, boolMode) {
             }
             else {
                 ackVal = uidValue;
-                uidValue = Buffer.from(uidValue, "utf8").toString("base64");
+                uidValue = Buffer.from(uidValue, normalizeTextEncoding(textEncoding)).toString("base64");
             }
         }
     }
@@ -87,7 +90,7 @@ function encodeUidValue(val, boolMode) {
                 method = "toggle";
             }
             else if (isNaN(Number(uidValue))) {
-                uidValue = Buffer.from(uidValue, "utf8").toString("base64");
+                uidValue = Buffer.from(uidValue, normalizeTextEncoding(textEncoding)).toString("base64");
             }
         }
     }
@@ -129,6 +132,7 @@ class GiraEndpointAdapter extends utils.Adapter {
         this.keyDescMap = new Map();
         this.keyCaseMap = new Map();
         this.forwardMap = new Map();
+        this.keyTextEncodingMap = new Map();
         this.reverseMap = new Map();
         this.boolKeys = new Set();
         this.suppressStateChange = new Set();
@@ -238,6 +242,7 @@ class GiraEndpointAdapter extends utils.Adapter {
             const boolKeys = new Set();
             const skipInitial = new Set();
             const updateOnStartSources = [];
+            const keyTextEncodingMap = new Map();
             this.keyCaseMap.clear();
             const rawKeys = Array.isArray(cfg.endpointGroups)
                 ? cfg.endpointGroups.flatMap((g) => Array.isArray(g?.keys) ? g.keys : [])
@@ -259,6 +264,8 @@ class GiraEndpointAdapter extends utils.Adapter {
                         const bool = Boolean(k.bool);
                         if (bool)
                             boolKeys.add(key);
+                        const textEncoding = normalizeTextEncoding(k.textEncoding);
+                        keyTextEncodingMap.set(key, textEncoding);
                         const updateOnStart = k.updateOnStart !== false;
                         if (!updateOnStart)
                             skipInitial.add(key);
@@ -269,6 +276,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                                 stateId: `${baseId}.value`,
                                 bool,
                                 foreign: false,
+                                textEncoding,
                             });
                         }
                         endpointKeys.push(key);
@@ -327,11 +335,13 @@ class GiraEndpointAdapter extends utils.Adapter {
                     const toState = Boolean(m.toState);
                     const bool = Boolean(m.bool);
                     const ack = m.ack !== false;
+                    const textEncoding = normalizeTextEncoding(m.textEncoding);
+                    keyTextEncodingMap.set(key, textEncoding);
                     const updateOnStart = m.updateOnStart !== false;
                     if (!updateOnStart)
                         skipInitial.add(key);
                     if (toEndpoint) {
-                        forwardMap.set(stateId, { key, bool });
+                        forwardMap.set(stateId, { key, bool, textEncoding });
                         if (bool)
                             boolKeys.add(key);
                         if (updateOnStart) {
@@ -340,6 +350,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                                 stateId,
                                 bool,
                                 foreign: true,
+                                textEncoding,
                             });
                         }
                     }
@@ -425,6 +436,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                     this.keyDescMap.set(key, key);
             }
             this.endpointKeys = endpointKeys;
+            this.keyTextEncodingMap = keyTextEncodingMap;
             const endpointKeysText = this.endpointKeys.length
                 ? this.endpointKeys.join(", ")
                 : this.translate("(none)");
@@ -1112,7 +1124,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                     : await this.getStateAsync(src.stateId);
                 if (!state)
                     continue;
-                const { uidValue, ackVal, method } = encodeUidValue(state.val, src.bool);
+                const { uidValue, ackVal, method } = encodeUidValue(state.val, src.bool, src.textEncoding);
                 this.client.call(src.key, method, uidValue);
                 const baseId = this.keyIdMap.get(src.key) ?? this.makeEndpointBaseId(src.key);
                 this.keyIdMap.set(src.key, baseId);
@@ -1183,7 +1195,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                 this.log.debug(this.translate("Ignoring state change for %s because it was just updated from endpoint", id));
                 return;
             }
-            const { uidValue, ackVal, method } = encodeUidValue(state.val, mapped.bool);
+            const { uidValue, ackVal, method } = encodeUidValue(state.val, mapped.bool, mapped.textEncoding);
             this.client.call(mapped.key, method, uidValue);
             const baseId = this.keyIdMap.get(mapped.key) ?? this.makeEndpointBaseId(mapped.key);
             this.keyIdMap.set(mapped.key, baseId);
@@ -1299,7 +1311,8 @@ class GiraEndpointAdapter extends utils.Adapter {
         const key = this.idKeyMap.get(baseId) ??
             this.normalizeKey(parts.slice(1, parts.length - 1).join("."));
         const boolKey = this.boolKeys.has(key);
-        const { uidValue, ackVal, method } = encodeUidValue(state.val, boolKey);
+        const textEncoding = this.keyTextEncodingMap.get(key) ?? "utf8";
+        const { uidValue, ackVal, method } = encodeUidValue(state.val, boolKey, textEncoding);
         this.client.call(key, method, uidValue);
         const mappedForeign = this.reverseMap.get(key);
         if (mappedForeign) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,8 @@ import { format } from "util";
 
 // Configuration options provided by ioBroker's admin interface
 // (extend as needed when more options are supported)
+type TextEncoding = "utf8" | "latin1";
+
 interface AdapterConfig extends ioBroker.AdapterConfig {
   host?: string;
   port?: number;
@@ -26,6 +28,7 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
         bool?: boolean;
         updateOnStart?: boolean;
         enabled?: boolean;
+        textEncoding?: TextEncoding;
       }[]
     | string;
   endpointGroups?: {
@@ -36,6 +39,7 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
       bool?: boolean;
       updateOnStart?: boolean;
       enabled?: boolean;
+      textEncoding?: TextEncoding;
     }[];
   }[];
   updateLastEvent?: boolean;
@@ -49,6 +53,7 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
     ack?: boolean;
     updateOnStart?: boolean;
     enabled?: boolean;
+    textEncoding?: TextEncoding;
   }[]; // legacy support
   mappingGroups?: {
     group?: string;
@@ -62,6 +67,7 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
       ack?: boolean;
       updateOnStart?: boolean;
       enabled?: boolean;
+      textEncoding?: TextEncoding;
     }[];
   }[];
   dataArchives?:
@@ -77,9 +83,14 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
     | string;
 }
 
+function normalizeTextEncoding(textEncoding: any): TextEncoding {
+  return textEncoding === "latin1" ? "latin1" : "utf8";
+}
+
 export function encodeUidValue(
   val: any,
-  boolMode: boolean
+  boolMode: boolean,
+  textEncoding: TextEncoding = "utf8"
 ): { uidValue: string; ackVal: any; method: "set" | "toggle" } {
   let method: "set" | "toggle" = "set";
   let uidValue: any = val;
@@ -104,7 +115,7 @@ export function encodeUidValue(
         uidValue = num ? "1" : "0";
       } else {
         ackVal = uidValue;
-        uidValue = Buffer.from(uidValue, "utf8").toString("base64");
+        uidValue = Buffer.from(uidValue, normalizeTextEncoding(textEncoding)).toString("base64");
       }
     }
   } else {
@@ -119,7 +130,7 @@ export function encodeUidValue(
         uidValue = "1";
         method = "toggle";
       } else if (isNaN(Number(uidValue))) {
-        uidValue = Buffer.from(uidValue, "utf8").toString("base64");
+        uidValue = Buffer.from(uidValue, normalizeTextEncoding(textEncoding)).toString("base64");
       }
     }
   }
@@ -149,14 +160,21 @@ class GiraEndpointAdapter extends utils.Adapter {
   private idKeyMap = new Map<string, string>();
   private keyDescMap = new Map<string, string>();
   private keyCaseMap = new Map<string, string>();
-  private forwardMap = new Map<string, { key: string; bool: boolean }>();
+  private forwardMap = new Map<string, { key: string; bool: boolean; textEncoding: TextEncoding }>();
+  private keyTextEncodingMap = new Map<string, TextEncoding>();
   private reverseMap = new Map<string, { stateId: string; bool: boolean; ack: boolean }>();
   private boolKeys = new Set<string>();
   private suppressStateChange = new Set<string>();
   private pendingUpdates = new Map<string, any>();
   private skipInitialUpdate = new Set<string>();
   private initialSkipUpdate = new Set<string>();
-  private updateOnStartSources: Array<{ key: string; stateId: string; bool: boolean; foreign: boolean }> = [];
+  private updateOnStartSources: Array<{
+    key: string;
+    stateId: string;
+    bool: boolean;
+    foreign: boolean;
+    textEncoding: TextEncoding;
+  }> = [];
   private pendingSubscriptions = new Set<string>();
   private isConnected = false;
   private pendingHsRestart = false;
@@ -287,7 +305,9 @@ class GiraEndpointAdapter extends utils.Adapter {
         stateId: string;
         bool: boolean;
         foreign: boolean;
+        textEncoding: TextEncoding;
       }> = [];
+      const keyTextEncodingMap = new Map<string, TextEncoding>();
 
       this.keyCaseMap.clear();
 
@@ -309,6 +329,8 @@ class GiraEndpointAdapter extends utils.Adapter {
             if (name) this.keyDescMap.set(key, name);
             const bool = Boolean((k as any).bool);
             if (bool) boolKeys.add(key);
+            const textEncoding = normalizeTextEncoding((k as any).textEncoding);
+            keyTextEncodingMap.set(key, textEncoding);
             const updateOnStart = (k as any).updateOnStart !== false;
             if (!updateOnStart) skipInitial.add(key);
             if (updateOnStart) {
@@ -318,6 +340,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                 stateId: `${baseId}.value`,
                 bool,
                 foreign: false,
+                textEncoding,
               });
             }
             endpointKeys.push(key);
@@ -342,7 +365,7 @@ class GiraEndpointAdapter extends utils.Adapter {
         }
       }
 
-      const forwardMap = new Map<string, { key: string; bool: boolean }>();
+      const forwardMap = new Map<string, { key: string; bool: boolean; textEncoding: TextEncoding }>();
       const reverseMap = new Map<string, { stateId: string; bool: boolean; ack: boolean }>();
       const mappingGroups = Array.isArray(cfg.mappingGroups)
         ? cfg.mappingGroups
@@ -367,10 +390,12 @@ class GiraEndpointAdapter extends utils.Adapter {
           const toState = Boolean((m as any).toState);
           const bool = Boolean((m as any).bool);
           const ack = (m as any).ack !== false;
+          const textEncoding = normalizeTextEncoding((m as any).textEncoding);
+          keyTextEncodingMap.set(key, textEncoding);
           const updateOnStart = (m as any).updateOnStart !== false;
           if (!updateOnStart) skipInitial.add(key);
           if (toEndpoint) {
-            forwardMap.set(stateId, { key, bool });
+            forwardMap.set(stateId, { key, bool, textEncoding });
             if (bool) boolKeys.add(key);
             if (updateOnStart) {
               updateOnStartSources.push({
@@ -378,6 +403,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                 stateId,
                 bool,
                 foreign: true,
+                textEncoding,
               });
             }
           }
@@ -393,7 +419,16 @@ class GiraEndpointAdapter extends utils.Adapter {
       this.boolKeys = boolKeys;
       this.skipInitialUpdate = skipInitial;
       this.initialSkipUpdate = new Set(skipInitial);
-      const uniqueSources = new Map<string, { key: string; stateId: string; bool: boolean; foreign: boolean }>();
+      const uniqueSources = new Map<
+        string,
+        {
+          key: string;
+          stateId: string;
+          bool: boolean;
+          foreign: boolean;
+          textEncoding: TextEncoding;
+        }
+      >();
       for (const src of updateOnStartSources) {
         const key = `${src.key}|${src.stateId}|${src.foreign ? "1" : "0"}`;
         if (!uniqueSources.has(key)) uniqueSources.set(key, src);
@@ -450,6 +485,7 @@ class GiraEndpointAdapter extends utils.Adapter {
         if (!this.keyDescMap.has(key)) this.keyDescMap.set(key, key);
       }
       this.endpointKeys = endpointKeys;
+      this.keyTextEncodingMap = keyTextEncodingMap;
 
       const endpointKeysText = this.endpointKeys.length
         ? this.endpointKeys.join(", ")
@@ -1250,7 +1286,7 @@ class GiraEndpointAdapter extends utils.Adapter {
           : await this.getStateAsync(src.stateId);
         if (!state) continue;
 
-        const { uidValue, ackVal, method } = encodeUidValue(state.val, src.bool);
+        const { uidValue, ackVal, method } = encodeUidValue(state.val, src.bool, src.textEncoding);
         this.client.call(src.key, method, uidValue);
 
         const baseId = this.keyIdMap.get(src.key) ?? this.makeEndpointBaseId(src.key);
@@ -1337,7 +1373,7 @@ class GiraEndpointAdapter extends utils.Adapter {
         );
         return;
       }
-      const { uidValue, ackVal, method } = encodeUidValue(state.val, mapped.bool);
+      const { uidValue, ackVal, method } = encodeUidValue(state.val, mapped.bool, mapped.textEncoding);
       this.client.call(mapped.key, method, uidValue);
       const baseId =
         this.keyIdMap.get(mapped.key) ?? this.makeEndpointBaseId(mapped.key);
@@ -1468,7 +1504,8 @@ class GiraEndpointAdapter extends utils.Adapter {
       this.idKeyMap.get(baseId) ??
       this.normalizeKey(parts.slice(1, parts.length - 1).join("."));
     const boolKey = this.boolKeys.has(key);
-    const { uidValue, ackVal, method } = encodeUidValue(state.val, boolKey);
+    const textEncoding = this.keyTextEncodingMap.get(key) ?? "utf8";
+    const { uidValue, ackVal, method } = encodeUidValue(state.val, boolKey, textEncoding);
     this.client.call(key, method, uidValue);
     const mappedForeign = this.reverseMap.get(key);
     if (mappedForeign) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -391,7 +391,9 @@ class GiraEndpointAdapter extends utils.Adapter {
           const bool = Boolean((m as any).bool);
           const ack = (m as any).ack !== false;
           const textEncoding = normalizeTextEncoding((m as any).textEncoding);
-          keyTextEncodingMap.set(key, textEncoding);
+          if (!keyTextEncodingMap.has(key)) {
+            keyTextEncodingMap.set(key, textEncoding);
+          }
           const updateOnStart = (m as any).updateOnStart !== false;
           if (!updateOnStart) skipInitial.add(key);
           if (toEndpoint) {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,3 +1,16 @@
+const assert = require("assert").strict;
+const { encodeUidValue } = require("../build/main");
+
+// Cover critical text encoding conversions in the test entrypoint run by npm test.
+assert.equal(
+  encodeUidValue("Hauptwäsche", false, "utf8").uidValue,
+  "SGF1cHR3w6RzY2hl"
+);
+assert.equal(
+  encodeUidValue("Hauptwäsche", false, "latin1").uidValue,
+  "SGF1cHR35HNjaGU="
+);
+
 const path = require("path");
 const { tests } = require("@iobroker/testing");
 

--- a/test/valueConversion.test.ts
+++ b/test/valueConversion.test.ts
@@ -20,6 +20,24 @@ describe("value conversion helpers", () => {
       assert.strictEqual(res.uidValue, Buffer.from("abc", "utf8").toString("base64"));
       assert.strictEqual(res.ackVal, "abc");
     });
+
+    it("encodes non-numeric text as UTF-8 by default", () => {
+      const res = encodeUidValue("Hauptwäsche", false, "utf8");
+      assert.strictEqual(res.uidValue, "SGF1cHR3w6RzY2hl");
+      assert.strictEqual(res.ackVal, "Hauptwäsche");
+    });
+
+    it("encodes non-numeric text as Latin1 when configured", () => {
+      const res = encodeUidValue("Hauptwäsche", false, "latin1");
+      assert.strictEqual(res.uidValue, "SGF1cHR35HNjaGU=");
+      assert.strictEqual(res.ackVal, "Hauptwäsche");
+    });
+
+    it("does not apply text encoding to numbers, booleans, or numeric strings", () => {
+      assert.strictEqual(encodeUidValue(1, false, "latin1").uidValue, "1");
+      assert.strictEqual(encodeUidValue(true, false, "latin1").uidValue, "1");
+      assert.strictEqual(encodeUidValue("123", false, "latin1").uidValue, "123");
+    });
   });
 
   describe("decodeAckValue", () => {


### PR DESCRIPTION
### Motivation
- Some non-numeric string values (Umlaute) are encoded incorrectly for CO endpoints when always using UTF-8 Base64, so an option to use Latin1 for text writes is needed to match the Homeserver/Visu expectations.
- The change must be opt-in per endpoint / mapping and keep existing behavior as default to avoid breaking current installations.
- The encoding must only affect non-numeric strings on the Adapter → HS write path and forward mappings, leaving HS → Adapter behavior unchanged.

### Description
- Added a `TextEncoding = "utf8" | "latin1"` type and a per-entry `textEncoding?: TextEncoding` config option for `endpointKeys`, `endpointGroups.keys`, legacy `mappings`, and `mappingGroups.mappings`, with a UI select in `admin/jsonConfig.json` defaulting to `utf8`.
- Introduced `normalizeTextEncoding()` and extended `encodeUidValue(val, boolMode, textEncoding = "utf8")` so non-numeric strings are Base64-encoded via `Buffer.from(value, textEncoding).toString("base64")`, while booleans, numbers, `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fa185ee088325870bb0645bb7457f)