### PR TITLE
Fix incoming CO text decoding

### DIFF
--- a/build/lib/GiraClient.js
+++ b/build/lib/GiraClient.js
@@ -258,14 +258,6 @@ class GiraClient extends events_1.EventEmitter {
             if (!isNaN(num)) {
                 v = num;
             }
-            else {
-                try {
-                    v = Buffer.from(v, "base64").toString("utf8");
-                }
-                catch {
-                    // ignorieren, wenn keine gültige Base64
-                }
-            }
         }
         return v;
     }

--- a/build/main.js
+++ b/build/main.js
@@ -35,6 +35,7 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.encodeUidValue = encodeUidValue;
 exports.decodeAckValue = decodeAckValue;
+exports.decodeCoValue = decodeCoValue;
 const utils = __importStar(require("@iobroker/adapter-core"));
 const GiraClient_1 = require("./lib/GiraClient");
 const crypto_1 = require("crypto");
@@ -113,6 +114,19 @@ function decodeAckValue(val, boolMode) {
             return { value: val, type: "string" };
         return { value: val, type: "mixed" };
     }
+}
+function decodeCoValue(rawValue, boolMode, textEncoding = "utf8") {
+    if (boolMode || typeof rawValue !== "string") {
+        return decodeAckValue(rawValue, boolMode);
+    }
+    const num = Number(rawValue);
+    if (!isNaN(num)) {
+        return { value: num, type: "number" };
+    }
+    return {
+        value: Buffer.from(rawValue, "base64").toString(normalizeTextEncoding(textEncoding)),
+        type: "string",
+    };
 }
 class GiraEndpointAdapter extends utils.Adapter {
     notifyAdmin(message) {
@@ -897,8 +911,9 @@ class GiraEndpointAdapter extends utils.Adapter {
                         continue;
                     }
                     const boolKey = this.boolKeys.has(normalized);
+                    const textEncoding = this.keyTextEncodingMap.get(normalized) ?? "utf8";
                     const rawVal = data.value;
-                    const decoded = decodeAckValue(rawVal, boolKey);
+                    const decoded = decodeCoValue(rawVal, boolKey, textEncoding);
                     const value = decoded.value;
                     const type = decoded.type;
                     const pending = this.pendingUpdates.get(normalized);

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,12 @@
 {
   "common": {
     "name": "gira-endpoint",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "news": {
+      "0.3.2": {
+        "en": "Decode incoming CO text values with configured UTF-8 or Latin1 encoding",
+        "de": "Eingehende CO-Textwerte mit konfigurierter UTF-8- oder Latin1-Kodierung dekodieren"
+      },
       "0.3.1": {
         "en": "Bump version to 0.3.1",
         "de": "Version auf 0.3.1 erhöht"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.gira-endpoint",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@iobroker/adapter-core": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "ioBroker adapter for Gira endpoint (WS/WSS) – emits events as states, minimal viable replacement for Node-RED Gira node",
   "author": "you",
   "license": "GPL-3.0-or-later",

--- a/src/lib/GiraClient.ts
+++ b/src/lib/GiraClient.ts
@@ -319,12 +319,6 @@ export class GiraClient extends EventEmitter {
       const num = Number(v);
       if (!isNaN(num)) {
         v = num;
-      } else {
-        try {
-          v = Buffer.from(v, "base64").toString("utf8");
-        } catch {
-          // ignorieren, wenn keine gültige Base64
-        }
       }
     }
     return v;

--- a/src/main.ts
+++ b/src/main.ts
@@ -153,6 +153,24 @@ export function decodeAckValue(
   }
 }
 
+export function decodeCoValue(
+  rawValue: any,
+  boolMode: boolean,
+  textEncoding: TextEncoding = "utf8"
+): { value: any; type: ioBroker.StateCommon["type"] } {
+  if (boolMode || typeof rawValue !== "string") {
+    return decodeAckValue(rawValue, boolMode);
+  }
+  const num = Number(rawValue);
+  if (!isNaN(num)) {
+    return { value: num, type: "number" };
+  }
+  return {
+    value: Buffer.from(rawValue, "base64").toString(normalizeTextEncoding(textEncoding)),
+    type: "string",
+  };
+}
+
 class GiraEndpointAdapter extends utils.Adapter {
   private client?: GiraClient;
   private endpointKeys: string[] = [];
@@ -1005,8 +1023,9 @@ class GiraEndpointAdapter extends utils.Adapter {
             continue;
           }
           const boolKey = this.boolKeys.has(normalized);
+          const textEncoding = this.keyTextEncodingMap.get(normalized) ?? "utf8";
           const rawVal = data.value;
-          const decoded = decodeAckValue(rawVal, boolKey);
+          const decoded = decodeCoValue(rawVal, boolKey, textEncoding);
           const value = decoded.value;
           const type = decoded.type;
 

--- a/test/valueConversion.test.ts
+++ b/test/valueConversion.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "assert";
 import { describe, it } from "mocha";
-const { encodeUidValue, decodeAckValue } = require("../src/main");
+const { encodeUidValue, decodeAckValue, decodeCoValue } = require("../src/main");
 
 describe("value conversion helpers", () => {
   describe("encodeUidValue", () => {
@@ -49,6 +49,23 @@ describe("value conversion helpers", () => {
     it("decodes boolean in number mode", () => {
       const res = decodeAckValue(true, false);
       assert.deepStrictEqual(res, { value: 1, type: "number" });
+    });
+  });
+
+  describe("decodeCoValue", () => {
+    it("decodes incoming Latin1 Base64 text with configured Latin1 encoding", () => {
+      const res = decodeCoValue("SGF1cHR35HNjaGUy", false, "latin1");
+      assert.deepStrictEqual(res, { value: "Hauptwäsche2", type: "string" });
+    });
+
+    it("decodes incoming UTF-8 Base64 text with default UTF-8 encoding", () => {
+      const res = decodeCoValue("SGF1cHR3w6RzY2hlMg==", false, "utf8");
+      assert.deepStrictEqual(res, { value: "Hauptwäsche2", type: "string" });
+    });
+
+    it("preserves numeric conversion for incoming numeric strings", () => {
+      const res = decodeCoValue("123", false, "latin1");
+      assert.deepStrictEqual(res, { value: 123, type: "number" });
     });
   });
 });


### PR DESCRIPTION
### Motivation

- Prevent unconditional Base64->UTF-8 decoding in the generic `GiraClient.normalizeValue()` which causes Latin1 CO text to be corrupted before the adapter can decide the correct encoding.
- Decode CO `value` payloads using the adapter-side normalized key context so the configured text encoding per key (`utf8` or `latin1`) can be applied.

### Description

- Stop eager text decoding in `GiraClient.normalizeValue()` and keep only numeric-string conversion there so generic JSON fields are not blindly decoded. (`src/lib/GiraClient.ts`)
- Add `decodeCoValue(rawValue, boolMode, textEncoding)` to handle inbound CO value semantics: keep boolean/number behavior, preserve numeric-string conversion, and Base64-decode non-numeric strings using the provided encoding. (`src/main.ts`)
- Move Base64 decoding of inbound CO `.value` fields into the adapter event path and select encoding via `this.keyTextEncodingMap.get(normalized) ?? "utf8"` before calling `decodeCoValue()`. (`src/main.ts`)
- Add regression tests for `decodeCoValue()` covering Latin1 and UTF-8 Base64 inputs resolving to `Hauptwäsche2` and numeric-string preservation. (`test/valueConversion.test.ts`)
- Bump package version to `0.3.2` and update `io-package.json` news entry to describe the fix. (`package.json`, `io-package.json`, `package-lock.json`)

### Testing

- Ran `npm run build`, which completed successfully.
- Ran a Node VM smoke test invoking `decodeCoValue()` on both Latin1 and UTF-8 Base64 samples and a numeric string, all checks passed.
- Attempted full `npm test` but it failed in this environment due to a missing `@iobroker/adapter-core` dependency (CI/local environment issue), so the full integration harness was not executed here.
- Attempted `npm install` to resolve test deps but the environment returned registry `403` for `@iobroker/testing`, so dev dependency installation could not be completed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fa7e7b4d883259b6946b8e1495060)