### PR TITLE
Move value conversion helpers, improve Gira call diagnostics and add debug logging for writes

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -1,5 +1,6 @@
 {
   "type": "tabs",
+  "i18n": false,
   "items": {
     "settingsTab": {
       "type": "panel",

--- a/build/lib/GiraClient.js
+++ b/build/lib/GiraClient.js
@@ -5,6 +5,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.GiraClient = void 0;
 exports.codeToMessage = codeToMessage;
+exports.formatCallError = formatCallError;
 const events_1 = require("events");
 const ws_1 = __importDefault(require("ws"));
 // Kein Listener-Limit (verhindert MaxListeners-Warnungen global hier)
@@ -24,6 +25,50 @@ const STATUS_CODE_MESSAGES = {
 };
 function codeToMessage(code) {
     return STATUS_CODE_MESSAGES[code] || `Error code ${code}`;
+}
+function shorten(value, maxLength = 200) {
+    return value.length > maxLength ? `${value.slice(0, maxLength)}…` : value;
+}
+function safeStringify(value) {
+    if (value === undefined)
+        return undefined;
+    try {
+        return JSON.stringify(value, (key, val) => {
+            const lower = String(key).toLowerCase();
+            if (lower.includes("password") || lower.includes("authorization")) {
+                return "[redacted]";
+            }
+            return val;
+        });
+    }
+    catch {
+        return String(value);
+    }
+}
+function formatCallError(payload, fallbackRequest) {
+    const code = Number(payload?.code);
+    const message = payload?.message || payload?.error || codeToMessage(code);
+    const request = payload?.request ?? fallbackRequest;
+    const source = payload?.param ?? payload?.data ?? request ?? {};
+    const key = payload?.key ?? source?.key;
+    const method = payload?.method ?? source?.method;
+    const value = payload?.value ?? source?.value;
+    const params = payload?.params ?? source?.params ?? source?.param;
+    const tag = payload?.tag ?? payload?.context;
+    const parts = [`code=${Number.isNaN(code) ? payload?.code : code}`, message];
+    if (key !== undefined)
+        parts.push(`key=${key}`);
+    if (method !== undefined)
+        parts.push(`method=${method}`);
+    if (value !== undefined)
+        parts.push(`value=${shorten(safeStringify(value) ?? String(value))}`);
+    if (params !== undefined)
+        parts.push(`params=${shorten(safeStringify(params) ?? String(params))}`);
+    if (tag !== undefined)
+        parts.push(`tag=${tag}`);
+    if (request !== undefined)
+        parts.push(`request=${shorten(safeStringify(request) ?? String(request))}`);
+    return `Gira call failed: ${parts.join(", ")}`;
 }
 class GiraClient extends events_1.EventEmitter {
     constructor(opts) {
@@ -105,11 +150,9 @@ class GiraClient extends events_1.EventEmitter {
                     typeof payload === "object" &&
                     payload.code !== undefined &&
                     payload.code !== 0) {
-                    const msg = payload.message ||
-                        payload.error ||
-                        codeToMessage(payload.code);
                     const tag = payload.tag;
-                    const err = new Error(msg);
+                    const fallbackRequest = payload?.request;
+                    const err = new Error(formatCallError(payload, fallbackRequest));
                     err.code = payload.code;
                     if (tag && this.tagResolvers.has(tag)) {
                         const resolver = this.tagResolvers.get(tag);
@@ -210,7 +253,7 @@ class GiraClient extends events_1.EventEmitter {
             const reqKey = this.makeRequestKey(param);
             return new Promise((resolve, reject) => {
                 const timer = setTimeout(() => {
-                    reject(new Error("Timeout"));
+                    reject(new Error(`Gira call failed: Timeout, key=${key}, method=${method}, tag=${tag}, params=${shorten(safeStringify(param) ?? String(param))}`));
                     this.tagResolvers.delete(tag);
                     this.requestTags.delete(reqKey);
                 }, timeoutMs);
@@ -227,7 +270,7 @@ class GiraClient extends events_1.EventEmitter {
             msg.tag = tag;
             return new Promise((resolve, reject) => {
                 const timer = setTimeout(() => {
-                    reject(new Error("Timeout"));
+                    reject(new Error(`Gira select failed: Timeout, tag=${tag}, params=${shorten(safeStringify(filter) ?? String(filter))}`));
                     this.tagResolvers.delete(tag);
                 }, timeoutMs);
                 this.tagResolvers.set(tag, { resolve, reject, timer });

--- a/build/lib/valueConversion.js
+++ b/build/lib/valueConversion.js
@@ -1,0 +1,94 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.normalizeTextEncoding = normalizeTextEncoding;
+exports.encodeUidValue = encodeUidValue;
+exports.decodeAckValue = decodeAckValue;
+exports.decodeCoValue = decodeCoValue;
+function normalizeTextEncoding(textEncoding) {
+    return textEncoding === "latin1" ? "latin1" : "utf8";
+}
+function encodeUidValue(val, boolMode, textEncoding = "utf8") {
+    let method = "set";
+    let uidValue = val;
+    let ackVal = val;
+    if (boolMode) {
+        if (typeof uidValue === "boolean") {
+            ackVal = uidValue;
+            uidValue = uidValue ? "1" : "0";
+        }
+        else if (typeof uidValue === "number") {
+            ackVal = uidValue !== 0;
+            uidValue = uidValue ? "1" : "0";
+        }
+        else if (typeof uidValue === "string") {
+            if (uidValue === "true" || uidValue === "false") {
+                ackVal = uidValue === "true";
+                uidValue = ackVal ? "1" : "0";
+            }
+            else if (uidValue === "toggle") {
+                uidValue = "1";
+                method = "toggle";
+            }
+            else if (!isNaN(Number(uidValue))) {
+                const num = Number(uidValue);
+                ackVal = num !== 0;
+                uidValue = num ? "1" : "0";
+            }
+            else {
+                ackVal = uidValue;
+                uidValue = Buffer.from(uidValue, normalizeTextEncoding(textEncoding)).toString("base64");
+            }
+        }
+    }
+    else {
+        if (typeof uidValue === "boolean") {
+            ackVal = uidValue ? 1 : 0;
+            uidValue = uidValue ? "1" : "0";
+        }
+        else if (typeof uidValue === "string") {
+            if (uidValue === "true" || uidValue === "false") {
+                ackVal = uidValue === "true" ? 1 : 0;
+                uidValue = uidValue === "true" ? "1" : "0";
+            }
+            else if (uidValue === "toggle") {
+                uidValue = "1";
+                method = "toggle";
+            }
+            else if (isNaN(Number(uidValue))) {
+                uidValue = Buffer.from(uidValue, normalizeTextEncoding(textEncoding)).toString("base64");
+            }
+        }
+    }
+    return { uidValue: String(uidValue), ackVal, method };
+}
+function decodeAckValue(val, boolMode) {
+    if (boolMode) {
+        if (typeof val === "number")
+            return { value: val !== 0, type: "boolean" };
+        if (typeof val === "string")
+            return { value: val !== "0", type: "boolean" };
+        return { value: Boolean(val), type: "boolean" };
+    }
+    else {
+        if (typeof val === "boolean")
+            return { value: val ? 1 : 0, type: "number" };
+        if (typeof val === "number")
+            return { value: val, type: "number" };
+        if (typeof val === "string")
+            return { value: val, type: "string" };
+        return { value: val, type: "mixed" };
+    }
+}
+function decodeCoValue(rawValue, boolMode, textEncoding = "utf8") {
+    if (boolMode || typeof rawValue !== "string") {
+        return decodeAckValue(rawValue, boolMode);
+    }
+    const num = Number(rawValue);
+    if (!isNaN(num)) {
+        return { value: num, type: "number" };
+    }
+    return {
+        value: Buffer.from(rawValue, "base64").toString(normalizeTextEncoding(textEncoding)),
+        type: "string",
+    };
+}

--- a/build/main.js
+++ b/build/main.js
@@ -33,102 +33,28 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.encodeUidValue = encodeUidValue;
-exports.decodeAckValue = decodeAckValue;
-exports.decodeCoValue = decodeCoValue;
 const utils = __importStar(require("@iobroker/adapter-core"));
 const GiraClient_1 = require("./lib/GiraClient");
 const crypto_1 = require("crypto");
 const util_1 = require("util");
-function normalizeTextEncoding(textEncoding) {
-    return textEncoding === "latin1" ? "latin1" : "utf8";
-}
-function encodeUidValue(val, boolMode, textEncoding = "utf8") {
-    let method = "set";
-    let uidValue = val;
-    let ackVal = val;
-    if (boolMode) {
-        if (typeof uidValue === "boolean") {
-            ackVal = uidValue;
-            uidValue = uidValue ? "1" : "0";
-        }
-        else if (typeof uidValue === "number") {
-            ackVal = uidValue !== 0;
-            uidValue = uidValue ? "1" : "0";
-        }
-        else if (typeof uidValue === "string") {
-            if (uidValue === "true" || uidValue === "false") {
-                ackVal = uidValue === "true";
-                uidValue = ackVal ? "1" : "0";
-            }
-            else if (uidValue === "toggle") {
-                uidValue = "1";
-                method = "toggle";
-            }
-            else if (!isNaN(Number(uidValue))) {
-                const num = Number(uidValue);
-                ackVal = num !== 0;
-                uidValue = num ? "1" : "0";
-            }
-            else {
-                ackVal = uidValue;
-                uidValue = Buffer.from(uidValue, normalizeTextEncoding(textEncoding)).toString("base64");
-            }
-        }
-    }
-    else {
-        if (typeof uidValue === "boolean") {
-            ackVal = uidValue ? 1 : 0;
-            uidValue = uidValue ? "1" : "0";
-        }
-        else if (typeof uidValue === "string") {
-            if (uidValue === "true" || uidValue === "false") {
-                ackVal = uidValue === "true" ? 1 : 0;
-                uidValue = uidValue === "true" ? "1" : "0";
-            }
-            else if (uidValue === "toggle") {
-                uidValue = "1";
-                method = "toggle";
-            }
-            else if (isNaN(Number(uidValue))) {
-                uidValue = Buffer.from(uidValue, normalizeTextEncoding(textEncoding)).toString("base64");
-            }
-        }
-    }
-    return { uidValue: String(uidValue), ackVal, method };
-}
-function decodeAckValue(val, boolMode) {
-    if (boolMode) {
-        if (typeof val === "number")
-            return { value: val !== 0, type: "boolean" };
-        if (typeof val === "string")
-            return { value: val !== "0", type: "boolean" };
-        return { value: Boolean(val), type: "boolean" };
-    }
-    else {
-        if (typeof val === "boolean")
-            return { value: val ? 1 : 0, type: "number" };
-        if (typeof val === "number")
-            return { value: val, type: "number" };
-        if (typeof val === "string")
-            return { value: val, type: "string" };
-        return { value: val, type: "mixed" };
-    }
-}
-function decodeCoValue(rawValue, boolMode, textEncoding = "utf8") {
-    if (boolMode || typeof rawValue !== "string") {
-        return decodeAckValue(rawValue, boolMode);
-    }
-    const num = Number(rawValue);
-    if (!isNaN(num)) {
-        return { value: num, type: "number" };
-    }
-    return {
-        value: Buffer.from(rawValue, "base64").toString(normalizeTextEncoding(textEncoding)),
-        type: "string",
-    };
-}
+const valueConversion_1 = require("./lib/valueConversion");
 class GiraEndpointAdapter extends utils.Adapter {
+    formatLogValue(value, maxLength = 200) {
+        let text;
+        try {
+            text = typeof value === "string" ? JSON.stringify(value) : JSON.stringify(value);
+        }
+        catch {
+            text = String(value);
+        }
+        if (text === undefined)
+            text = String(value);
+        return text.length > maxLength ? `${text.slice(0, maxLength)}…` : text;
+    }
+    logOutgoingCoValue(args) {
+        const statePart = args.stateId ? ` stateId=${args.stateId}` : "";
+        this.log.debug(`Sending CO value source=${args.source}${statePart} key=${args.key} method=${args.method} ackVal=${this.formatLogValue(args.ackVal)} uidValue=${this.formatLogValue(args.uidValue)} bool=${args.bool} textEncoding=${args.textEncoding}`);
+    }
     notifyAdmin(message) {
         this.sendTo("admin", "messageBox", {
             title: "gira-endpoint",
@@ -278,7 +204,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                         const bool = Boolean(k.bool);
                         if (bool)
                             boolKeys.add(key);
-                        const textEncoding = normalizeTextEncoding(k.textEncoding);
+                        const textEncoding = (0, valueConversion_1.normalizeTextEncoding)(k.textEncoding);
                         keyTextEncodingMap.set(key, textEncoding);
                         const updateOnStart = k.updateOnStart !== false;
                         if (!updateOnStart)
@@ -349,7 +275,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                     const toState = Boolean(m.toState);
                     const bool = Boolean(m.bool);
                     const ack = m.ack !== false;
-                    const textEncoding = normalizeTextEncoding(m.textEncoding);
+                    const textEncoding = (0, valueConversion_1.normalizeTextEncoding)(m.textEncoding);
                     if (!keyTextEncodingMap.has(key)) {
                         keyTextEncodingMap.set(key, textEncoding);
                     }
@@ -913,7 +839,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                     const boolKey = this.boolKeys.has(normalized);
                     const textEncoding = this.keyTextEncodingMap.get(normalized) ?? "utf8";
                     const rawVal = data.value;
-                    const decoded = decodeCoValue(rawVal, boolKey, textEncoding);
+                    const decoded = (0, valueConversion_1.decodeCoValue)(rawVal, boolKey, textEncoding);
                     const value = decoded.value;
                     const type = decoded.type;
                     const pending = this.pendingUpdates.get(normalized);
@@ -1033,7 +959,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                         if (isValue) {
                             const mappedForeign = this.reverseMap.get(normalized);
                             if (mappedForeign) {
-                                let mappedVal = decodeAckValue(val, mappedForeign.bool).value;
+                                let mappedVal = (0, valueConversion_1.decodeAckValue)(val, mappedForeign.bool).value;
                                 this.log.debug(this.translate("Updating mapped foreign state %s -> %s", mappedForeign.stateId, JSON.stringify(mappedVal)));
                                 this.suppressStateChange.add(mappedForeign.stateId);
                                 await this.setForeignStateAsync(mappedForeign.stateId, {
@@ -1141,7 +1067,17 @@ class GiraEndpointAdapter extends utils.Adapter {
                     : await this.getStateAsync(src.stateId);
                 if (!state)
                     continue;
-                const { uidValue, ackVal, method } = encodeUidValue(state.val, src.bool, src.textEncoding);
+                const { uidValue, ackVal, method } = (0, valueConversion_1.encodeUidValue)(state.val, src.bool, src.textEncoding);
+                this.logOutgoingCoValue({
+                    source: "updateOnStart",
+                    stateId: src.stateId,
+                    key: src.key,
+                    method,
+                    ackVal,
+                    uidValue,
+                    bool: src.bool,
+                    textEncoding: src.textEncoding,
+                });
                 this.client.call(src.key, method, uidValue);
                 const baseId = this.keyIdMap.get(src.key) ?? this.makeEndpointBaseId(src.key);
                 this.keyIdMap.set(src.key, baseId);
@@ -1149,7 +1085,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                 await this.setStateAsync(`${baseId}.value`, { val: ackVal, ack: true });
                 const mappedForeign = this.reverseMap.get(src.key);
                 if (mappedForeign) {
-                    const mappedVal = decodeAckValue(ackVal, mappedForeign.bool).value;
+                    const mappedVal = (0, valueConversion_1.decodeAckValue)(ackVal, mappedForeign.bool).value;
                     this.suppressStateChange.add(mappedForeign.stateId);
                     await this.setForeignStateAsync(mappedForeign.stateId, {
                         val: mappedVal,
@@ -1212,7 +1148,17 @@ class GiraEndpointAdapter extends utils.Adapter {
                 this.log.debug(this.translate("Ignoring state change for %s because it was just updated from endpoint", id));
                 return;
             }
-            const { uidValue, ackVal, method } = encodeUidValue(state.val, mapped.bool, mapped.textEncoding);
+            const { uidValue, ackVal, method } = (0, valueConversion_1.encodeUidValue)(state.val, mapped.bool, mapped.textEncoding);
+            this.logOutgoingCoValue({
+                source: "mapping",
+                stateId: id,
+                key: mapped.key,
+                method,
+                ackVal,
+                uidValue,
+                bool: mapped.bool,
+                textEncoding: mapped.textEncoding,
+            });
             this.client.call(mapped.key, method, uidValue);
             const baseId = this.keyIdMap.get(mapped.key) ?? this.makeEndpointBaseId(mapped.key);
             this.keyIdMap.set(mapped.key, baseId);
@@ -1329,11 +1275,21 @@ class GiraEndpointAdapter extends utils.Adapter {
             this.normalizeKey(parts.slice(1, parts.length - 1).join("."));
         const boolKey = this.boolKeys.has(key);
         const textEncoding = this.keyTextEncodingMap.get(key) ?? "utf8";
-        const { uidValue, ackVal, method } = encodeUidValue(state.val, boolKey, textEncoding);
+        const { uidValue, ackVal, method } = (0, valueConversion_1.encodeUidValue)(state.val, boolKey, textEncoding);
+        this.logOutgoingCoValue({
+            source: "direct",
+            stateId: id,
+            key,
+            method,
+            ackVal,
+            uidValue,
+            bool: boolKey,
+            textEncoding,
+        });
         this.client.call(key, method, uidValue);
         const mappedForeign = this.reverseMap.get(key);
         if (mappedForeign) {
-            let mappedVal = decodeAckValue(ackVal, mappedForeign.bool).value;
+            let mappedVal = (0, valueConversion_1.decodeAckValue)(ackVal, mappedForeign.bool).value;
             this.log.debug(`Updating mapped foreign state ${mappedForeign.stateId} -> ${JSON.stringify(mappedVal)}`);
             this.suppressStateChange.add(mappedForeign.stateId);
             this.setForeignState(mappedForeign.stateId, {
@@ -1379,8 +1335,9 @@ class GiraEndpointAdapter extends utils.Adapter {
 }
 if (module.parent) {
     module.exports = (options) => new GiraEndpointAdapter(options);
-    module.exports.encodeUidValue = encodeUidValue;
-    module.exports.decodeAckValue = decodeAckValue;
+    module.exports.encodeUidValue = valueConversion_1.encodeUidValue;
+    module.exports.decodeAckValue = valueConversion_1.decodeAckValue;
+    module.exports.decodeCoValue = valueConversion_1.decodeCoValue;
 }
 else {
     (() => new GiraEndpointAdapter())();

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,12 @@
 {
   "common": {
     "name": "gira-endpoint",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "news": {
+      "0.3.3": {
+        "en": "Improve admin config validation, value conversion structure, and Gira call diagnostics",
+        "de": "Verbessert Admin-Konfig-Validierung, Werte-Konvertierung und Diagnose von Gira-Aufrufen"
+      },
       "0.3.2": {
         "en": "Decode incoming CO text values with configured UTF-8 or Latin1 encoding",
         "de": "Eingehende CO-Textwerte mit konfigurierter UTF-8- oder Latin1-Kodierung dekodieren"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "ioBroker adapter for Gira endpoint (WS/WSS) – emits events as states, minimal viable replacement for Node-RED Gira node",
   "author": "you",
   "license": "GPL-3.0-or-later",

--- a/src/lib/GiraClient.ts
+++ b/src/lib/GiraClient.ts
@@ -23,6 +23,45 @@ export function codeToMessage(code: number): string {
   return STATUS_CODE_MESSAGES[code] || `Error code ${code}`;
 }
 
+function shorten(value: string, maxLength = 200): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}…` : value;
+}
+
+function safeStringify(value: any): string | undefined {
+  if (value === undefined) return undefined;
+  try {
+    return JSON.stringify(value, (key, val) => {
+      const lower = String(key).toLowerCase();
+      if (lower.includes("password") || lower.includes("authorization")) {
+        return "[redacted]";
+      }
+      return val;
+    });
+  } catch {
+    return String(value);
+  }
+}
+
+export function formatCallError(payload: any, fallbackRequest?: any): string {
+  const code = Number(payload?.code);
+  const message = payload?.message || payload?.error || codeToMessage(code);
+  const request = payload?.request ?? fallbackRequest;
+  const source = payload?.param ?? payload?.data ?? request ?? {};
+  const key = payload?.key ?? source?.key;
+  const method = payload?.method ?? source?.method;
+  const value = payload?.value ?? source?.value;
+  const params = payload?.params ?? source?.params ?? source?.param;
+  const tag = payload?.tag ?? payload?.context;
+  const parts = [`code=${Number.isNaN(code) ? payload?.code : code}`, message];
+  if (key !== undefined) parts.push(`key=${key}`);
+  if (method !== undefined) parts.push(`method=${method}`);
+  if (value !== undefined) parts.push(`value=${shorten(safeStringify(value) ?? String(value))}`);
+  if (params !== undefined) parts.push(`params=${shorten(safeStringify(params) ?? String(params))}`);
+  if (tag !== undefined) parts.push(`tag=${tag}`);
+  if (request !== undefined) parts.push(`request=${shorten(safeStringify(request) ?? String(request))}`);
+  return `Gira call failed: ${parts.join(", ")}`;
+}
+
 interface ReconnectOptions {
   minMs: number;
   maxMs: number;
@@ -158,12 +197,9 @@ export class GiraClient extends EventEmitter {
           payload.code !== undefined &&
           payload.code !== 0
         ) {
-          const msg =
-            (payload as any).message ||
-            (payload as any).error ||
-            codeToMessage(payload.code);
           const tag = (payload as any).tag;
-          const err: any = new Error(msg);
+          const fallbackRequest = payload?.request;
+          const err: any = new Error(formatCallError(payload, fallbackRequest));
           err.code = payload.code;
           if (tag && this.tagResolvers.has(tag)) {
             const resolver = this.tagResolvers.get(tag);
@@ -264,7 +300,7 @@ export class GiraClient extends EventEmitter {
       const reqKey = this.makeRequestKey(param);
       return new Promise((resolve, reject) => {
         const timer = setTimeout(() => {
-          reject(new Error("Timeout"));
+          reject(new Error(`Gira call failed: Timeout, key=${key}, method=${method}, tag=${tag}, params=${shorten(safeStringify(param) ?? String(param))}`));
           this.tagResolvers.delete(tag);
           this.requestTags.delete(reqKey);
         }, timeoutMs);
@@ -286,7 +322,7 @@ export class GiraClient extends EventEmitter {
       msg.tag = tag;
       return new Promise((resolve, reject) => {
         const timer = setTimeout(() => {
-          reject(new Error("Timeout"));
+          reject(new Error(`Gira select failed: Timeout, tag=${tag}, params=${shorten(safeStringify(filter) ?? String(filter))}`));
           this.tagResolvers.delete(tag);
         }, timeoutMs);
         this.tagResolvers.set(tag, { resolve, reject, timer });

--- a/src/lib/valueConversion.ts
+++ b/src/lib/valueConversion.ts
@@ -1,0 +1,89 @@
+export type TextEncoding = "utf8" | "latin1";
+
+export function normalizeTextEncoding(textEncoding: any): TextEncoding {
+  return textEncoding === "latin1" ? "latin1" : "utf8";
+}
+
+export function encodeUidValue(
+  val: any,
+  boolMode: boolean,
+  textEncoding: TextEncoding = "utf8"
+): { uidValue: string; ackVal: any; method: "set" | "toggle" } {
+  let method: "set" | "toggle" = "set";
+  let uidValue: any = val;
+  let ackVal: any = val;
+  if (boolMode) {
+    if (typeof uidValue === "boolean") {
+      ackVal = uidValue;
+      uidValue = uidValue ? "1" : "0";
+    } else if (typeof uidValue === "number") {
+      ackVal = uidValue !== 0;
+      uidValue = uidValue ? "1" : "0";
+    } else if (typeof uidValue === "string") {
+      if (uidValue === "true" || uidValue === "false") {
+        ackVal = uidValue === "true";
+        uidValue = ackVal ? "1" : "0";
+      } else if (uidValue === "toggle") {
+        uidValue = "1";
+        method = "toggle";
+      } else if (!isNaN(Number(uidValue))) {
+        const num = Number(uidValue);
+        ackVal = num !== 0;
+        uidValue = num ? "1" : "0";
+      } else {
+        ackVal = uidValue;
+        uidValue = Buffer.from(uidValue, normalizeTextEncoding(textEncoding)).toString("base64");
+      }
+    }
+  } else {
+    if (typeof uidValue === "boolean") {
+      ackVal = uidValue ? 1 : 0;
+      uidValue = uidValue ? "1" : "0";
+    } else if (typeof uidValue === "string") {
+      if (uidValue === "true" || uidValue === "false") {
+        ackVal = uidValue === "true" ? 1 : 0;
+        uidValue = uidValue === "true" ? "1" : "0";
+      } else if (uidValue === "toggle") {
+        uidValue = "1";
+        method = "toggle";
+      } else if (isNaN(Number(uidValue))) {
+        uidValue = Buffer.from(uidValue, normalizeTextEncoding(textEncoding)).toString("base64");
+      }
+    }
+  }
+  return { uidValue: String(uidValue), ackVal, method };
+}
+
+export function decodeAckValue(
+  val: any,
+  boolMode: boolean
+): { value: any; type: ioBroker.StateCommon["type"] } {
+  if (boolMode) {
+    if (typeof val === "number") return { value: val !== 0, type: "boolean" };
+    if (typeof val === "string") return { value: val !== "0", type: "boolean" };
+    return { value: Boolean(val), type: "boolean" };
+  } else {
+    if (typeof val === "boolean") return { value: val ? 1 : 0, type: "number" };
+    if (typeof val === "number") return { value: val, type: "number" };
+    if (typeof val === "string") return { value: val, type: "string" };
+    return { value: val, type: "mixed" };
+  }
+}
+
+export function decodeCoValue(
+  rawValue: any,
+  boolMode: boolean,
+  textEncoding: TextEncoding = "utf8"
+): { value: any; type: ioBroker.StateCommon["type"] } {
+  if (boolMode || typeof rawValue !== "string") {
+    return decodeAckValue(rawValue, boolMode);
+  }
+  const num = Number(rawValue);
+  if (!isNaN(num)) {
+    return { value: num, type: "number" };
+  }
+  return {
+    value: Buffer.from(rawValue, "base64").toString(normalizeTextEncoding(textEncoding)),
+    type: "string",
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,11 +2,10 @@ import * as utils from "@iobroker/adapter-core";
 import { GiraClient, codeToMessage } from "./lib/GiraClient";
 import { randomUUID } from "crypto";
 import { format } from "util";
+import { decodeAckValue, decodeCoValue, encodeUidValue, normalizeTextEncoding, TextEncoding } from "./lib/valueConversion";
 
 // Configuration options provided by ioBroker's admin interface
 // (extend as needed when more options are supported)
-type TextEncoding = "utf8" | "latin1";
-
 interface AdapterConfig extends ioBroker.AdapterConfig {
   host?: string;
   port?: number;
@@ -83,93 +82,6 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
     | string;
 }
 
-function normalizeTextEncoding(textEncoding: any): TextEncoding {
-  return textEncoding === "latin1" ? "latin1" : "utf8";
-}
-
-export function encodeUidValue(
-  val: any,
-  boolMode: boolean,
-  textEncoding: TextEncoding = "utf8"
-): { uidValue: string; ackVal: any; method: "set" | "toggle" } {
-  let method: "set" | "toggle" = "set";
-  let uidValue: any = val;
-  let ackVal: any = val;
-  if (boolMode) {
-    if (typeof uidValue === "boolean") {
-      ackVal = uidValue;
-      uidValue = uidValue ? "1" : "0";
-    } else if (typeof uidValue === "number") {
-      ackVal = uidValue !== 0;
-      uidValue = uidValue ? "1" : "0";
-    } else if (typeof uidValue === "string") {
-      if (uidValue === "true" || uidValue === "false") {
-        ackVal = uidValue === "true";
-        uidValue = ackVal ? "1" : "0";
-      } else if (uidValue === "toggle") {
-        uidValue = "1";
-        method = "toggle";
-      } else if (!isNaN(Number(uidValue))) {
-        const num = Number(uidValue);
-        ackVal = num !== 0;
-        uidValue = num ? "1" : "0";
-      } else {
-        ackVal = uidValue;
-        uidValue = Buffer.from(uidValue, normalizeTextEncoding(textEncoding)).toString("base64");
-      }
-    }
-  } else {
-    if (typeof uidValue === "boolean") {
-      ackVal = uidValue ? 1 : 0;
-      uidValue = uidValue ? "1" : "0";
-    } else if (typeof uidValue === "string") {
-      if (uidValue === "true" || uidValue === "false") {
-        ackVal = uidValue === "true" ? 1 : 0;
-        uidValue = uidValue === "true" ? "1" : "0";
-      } else if (uidValue === "toggle") {
-        uidValue = "1";
-        method = "toggle";
-      } else if (isNaN(Number(uidValue))) {
-        uidValue = Buffer.from(uidValue, normalizeTextEncoding(textEncoding)).toString("base64");
-      }
-    }
-  }
-  return { uidValue: String(uidValue), ackVal, method };
-}
-
-export function decodeAckValue(
-  val: any,
-  boolMode: boolean
-): { value: any; type: ioBroker.StateCommon["type"] } {
-  if (boolMode) {
-    if (typeof val === "number") return { value: val !== 0, type: "boolean" };
-    if (typeof val === "string") return { value: val !== "0", type: "boolean" };
-    return { value: Boolean(val), type: "boolean" };
-  } else {
-    if (typeof val === "boolean") return { value: val ? 1 : 0, type: "number" };
-    if (typeof val === "number") return { value: val, type: "number" };
-    if (typeof val === "string") return { value: val, type: "string" };
-    return { value: val, type: "mixed" };
-  }
-}
-
-export function decodeCoValue(
-  rawValue: any,
-  boolMode: boolean,
-  textEncoding: TextEncoding = "utf8"
-): { value: any; type: ioBroker.StateCommon["type"] } {
-  if (boolMode || typeof rawValue !== "string") {
-    return decodeAckValue(rawValue, boolMode);
-  }
-  const num = Number(rawValue);
-  if (!isNaN(num)) {
-    return { value: num, type: "number" };
-  }
-  return {
-    value: Buffer.from(rawValue, "base64").toString(normalizeTextEncoding(textEncoding)),
-    type: "string",
-  };
-}
 
 class GiraEndpointAdapter extends utils.Adapter {
   private client?: GiraClient;
@@ -205,6 +117,34 @@ class GiraEndpointAdapter extends utils.Adapter {
     { from?: string; to?: string; columns?: string[] }
   >();
   private fetchedMeta = new Set<string>();
+
+
+  private formatLogValue(value: any, maxLength = 200): string {
+    let text: string;
+    try {
+      text = typeof value === "string" ? JSON.stringify(value) : JSON.stringify(value);
+    } catch {
+      text = String(value);
+    }
+    if (text === undefined) text = String(value);
+    return text.length > maxLength ? `${text.slice(0, maxLength)}…` : text;
+  }
+
+  private logOutgoingCoValue(args: {
+    source: "direct" | "mapping" | "updateOnStart";
+    stateId?: string;
+    key: string;
+    method: "set" | "toggle";
+    ackVal: any;
+    uidValue: string;
+    bool: boolean;
+    textEncoding: TextEncoding;
+  }): void {
+    const statePart = args.stateId ? ` stateId=${args.stateId}` : "";
+    this.log.debug(
+      `Sending CO value source=${args.source}${statePart} key=${args.key} method=${args.method} ackVal=${this.formatLogValue(args.ackVal)} uidValue=${this.formatLogValue(args.uidValue)} bool=${args.bool} textEncoding=${args.textEncoding}`
+    );
+  }
 
   private notifyAdmin(message: string): void {
     this.sendTo("admin", "messageBox", {
@@ -1308,6 +1248,16 @@ class GiraEndpointAdapter extends utils.Adapter {
         if (!state) continue;
 
         const { uidValue, ackVal, method } = encodeUidValue(state.val, src.bool, src.textEncoding);
+        this.logOutgoingCoValue({
+          source: "updateOnStart",
+          stateId: src.stateId,
+          key: src.key,
+          method,
+          ackVal,
+          uidValue,
+          bool: src.bool,
+          textEncoding: src.textEncoding,
+        });
         this.client.call(src.key, method, uidValue);
 
         const baseId = this.keyIdMap.get(src.key) ?? this.makeEndpointBaseId(src.key);
@@ -1395,6 +1345,16 @@ class GiraEndpointAdapter extends utils.Adapter {
         return;
       }
       const { uidValue, ackVal, method } = encodeUidValue(state.val, mapped.bool, mapped.textEncoding);
+      this.logOutgoingCoValue({
+        source: "mapping",
+        stateId: id,
+        key: mapped.key,
+        method,
+        ackVal,
+        uidValue,
+        bool: mapped.bool,
+        textEncoding: mapped.textEncoding,
+      });
       this.client.call(mapped.key, method, uidValue);
       const baseId =
         this.keyIdMap.get(mapped.key) ?? this.makeEndpointBaseId(mapped.key);
@@ -1527,6 +1487,16 @@ class GiraEndpointAdapter extends utils.Adapter {
     const boolKey = this.boolKeys.has(key);
     const textEncoding = this.keyTextEncodingMap.get(key) ?? "utf8";
     const { uidValue, ackVal, method } = encodeUidValue(state.val, boolKey, textEncoding);
+    this.logOutgoingCoValue({
+      source: "direct",
+      stateId: id,
+      key,
+      method,
+      ackVal,
+      uidValue,
+      bool: boolKey,
+      textEncoding,
+    });
     this.client.call(key, method, uidValue);
     const mappedForeign = this.reverseMap.get(key);
     if (mappedForeign) {
@@ -1593,6 +1563,7 @@ if (module.parent) {
   module.exports = (options: any) => new GiraEndpointAdapter(options);
   (module.exports as any).encodeUidValue = encodeUidValue;
   (module.exports as any).decodeAckValue = decodeAckValue;
+  (module.exports as any).decodeCoValue = decodeCoValue;
 } else {
   (() => new GiraEndpointAdapter())();
 }

--- a/test/valueConversion.test.ts
+++ b/test/valueConversion.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "assert";
 import { describe, it } from "mocha";
-const { encodeUidValue, decodeAckValue, decodeCoValue } = require("../src/main");
+const { encodeUidValue, decodeAckValue, decodeCoValue } = require("../build/lib/valueConversion");
 
 describe("value conversion helpers", () => {
   describe("encodeUidValue", () => {


### PR DESCRIPTION
### Motivation
- Clean up `main.ts` by extracting value encoding/decoding to a dedicated helper file while preserving existing Latin1/UTF-8 behavior and adapter config compatibility. 
- Make call failures from the HS/Gira client more actionable by including code/key/method/tag/params context and redacting sensitive fields. 
- Add debug-only logging for all adapter→HS write paths to make write operations traceable without changing runtime behavior. 

### Description
- Add root `"i18n": false` to `admin/jsonConfig.json` to silence the jsonConfig validation warning. 
- Add `src/lib/valueConversion.ts` exporting `TextEncoding`, `normalizeTextEncoding`, `encodeUidValue`, `decodeAckValue`, and `decodeCoValue`, and update `src/main.ts` to import and use these functions so behavior is unchanged. 
- Enhance `src/lib/GiraClient.ts` with `formatCallError` (plus small helpers) to format errors with `code`, message, `key`, `method`, truncated `value`/`params`, `tag`, and `request`, and use the formatter for incoming error payloads and timeouts. 
- Add debug logging helpers in `src/main.ts` (`formatLogValue` and `logOutgoingCoValue`) and instrument all CO write paths (`direct`, `mapping`, `updateOnStart`) to log `source`, optional `stateId`, `key`, `method`, truncated `ackVal`, `uidValue`, `bool`, and `textEncoding` at debug level only. 
- Bump package versions to `0.3.3` and add a short NEWS entry summarizing the change. 
- Update tests to import the moved helpers from `build/lib/valueConversion` (kept existing test semantics). 

### Testing
- Ran `npm run build` successfully which produced updated `build/` artifacts. 
- Executed isolated Node assertions against `build/lib/valueConversion` (checks for UTF-8/Latin1 encoding, numeric/boolean handling) and they passed. 
- Attempted to run the Mocha test (`npx mocha -r ts-node/register test/valueConversion.test.ts`), but the run failed due to external registry access returning `403 Forbidden` while fetching test dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fae19e8a0832591c04958b3cf0f48)