### PR TITLE
Refactor onStateChange routing and fix conversion test imports

### DIFF
--- a/build/main.js
+++ b/build/main.js
@@ -1143,51 +1143,59 @@ class GiraEndpointAdapter extends utils.Adapter {
         if (!state || !this.client)
             return;
         const mapped = this.forwardMap.get(id);
-        if (mapped) {
-            if (this.suppressStateChange.has(id)) {
-                this.log.debug(this.translate("Ignoring state change for %s because it was just updated from endpoint", id));
-                return;
-            }
-            const { uidValue, ackVal, method } = (0, valueConversion_1.encodeUidValue)(state.val, mapped.bool, mapped.textEncoding);
-            this.logOutgoingCoValue({
-                source: "mapping",
-                stateId: id,
-                key: mapped.key,
-                method,
-                ackVal,
-                uidValue,
-                bool: mapped.bool,
-                textEncoding: mapped.textEncoding,
-            });
-            this.client.call(mapped.key, method, uidValue);
-            const baseId = this.keyIdMap.get(mapped.key) ?? this.makeEndpointBaseId(mapped.key);
-            this.keyIdMap.set(mapped.key, baseId);
-            this.idKeyMap.set(baseId, mapped.key);
-            this.setState(`${baseId}.value`, { val: ackVal, ack: true });
-            if (!state.ack) {
-                this.suppressStateChange.add(id);
-                this.setForeignState(id, { val: state.val, ack: true });
-                const supTimer = this.setTimeout(() => {
-                    this.suppressStateChange.delete(id);
-                    this.clearTimeout(supTimer);
-                }, 1000);
-            }
-            this.pendingUpdates.set(mapped.key, ackVal);
-            const timer = this.setTimeout(() => {
-                this.pendingUpdates.delete(mapped.key);
-                this.clearTimeout(timer);
-            }, 1000);
+        if (mapped && this.handleMappedStateChange(id, state, mapped))
             return;
+        if (this.handleArchiveStateChange(id, state))
+            return;
+        if (this.handleDirectCoStateChange(id, state))
+            return;
+    }
+    handleMappedStateChange(id, state, mapped) {
+        if (this.suppressStateChange.has(id)) {
+            this.log.debug(this.translate("Ignoring state change for %s because it was just updated from endpoint", id));
+            return true;
         }
+        const { uidValue, ackVal, method } = (0, valueConversion_1.encodeUidValue)(state.val, mapped.bool, mapped.textEncoding);
+        this.logOutgoingCoValue({
+            source: "mapping",
+            stateId: id,
+            key: mapped.key,
+            method,
+            ackVal,
+            uidValue,
+            bool: mapped.bool,
+            textEncoding: mapped.textEncoding,
+        });
+        this.client.call(mapped.key, method, uidValue);
+        const baseId = this.keyIdMap.get(mapped.key) ?? this.makeEndpointBaseId(mapped.key);
+        this.keyIdMap.set(mapped.key, baseId);
+        this.idKeyMap.set(baseId, mapped.key);
+        this.setState(`${baseId}.value`, { val: ackVal, ack: true });
+        if (!state.ack) {
+            this.suppressStateChange.add(id);
+            this.setForeignState(id, { val: state.val, ack: true });
+            const supTimer = this.setTimeout(() => {
+                this.suppressStateChange.delete(id);
+                this.clearTimeout(supTimer);
+            }, 1000);
+        }
+        this.pendingUpdates.set(mapped.key, ackVal);
+        const timer = this.setTimeout(() => {
+            this.pendingUpdates.delete(mapped.key);
+            this.clearTimeout(timer);
+        }, 1000);
+        return true;
+    }
+    handleArchiveStateChange(id, state) {
         if (id.startsWith("DA@.")) {
             if (state.ack)
-                return;
+                return true;
             const parts = id.split(".");
             const action = parts.pop();
             const baseId = parts.join(".");
             const key = this.archiveIdKeyMap.get(baseId);
             if (!key || !action)
-                return;
+                return true;
             if (action === "meta") {
                 const prom = this.client.call(key, "meta", undefined, this.makeTag("meta"));
                 if (prom) {
@@ -1214,7 +1222,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                 }
                 catch {
                     this.log.warn(this.translate("Invalid query parameters for %s: %s", id, state.val));
-                    return;
+                    return true;
                 }
                 const prom = this.client.call(key, "get", params, this.makeTag("get"));
                 if (prom) {
@@ -1231,19 +1239,19 @@ class GiraEndpointAdapter extends utils.Adapter {
                     });
                 }
             }
-            return;
+            return true;
         }
         if (id.startsWith("CO@.")) {
             const parts = id.split(".");
             const action = parts.pop();
             if (action === "meta") {
                 if (state.ack)
-                    return;
+                    return true;
                 const baseId = parts.join(".");
                 const key = this.idKeyMap.get(baseId) ??
                     this.normalizeKey(parts.slice(1).join("."));
                 if (!key)
-                    return;
+                    return true;
                 if (action === "meta") {
                     const prom = this.client.call(key, "meta", undefined, this.makeTag("meta"));
                     if (prom) {
@@ -1259,17 +1267,20 @@ class GiraEndpointAdapter extends utils.Adapter {
                             this.log.error(this.translate("Meta call failed for %s: %s", key, err?.message || err));
                         });
                     }
-                    return;
+                    return true;
                 }
             }
         }
+        return false;
+    }
+    handleDirectCoStateChange(id, state) {
         if (state.ack)
-            return;
+            return false;
         if (!id.startsWith("CO@."))
-            return;
+            return false;
         const parts = id.split(".");
         if (parts[parts.length - 1] !== "value")
-            return;
+            return false;
         const baseId = parts.slice(0, parts.length - 1).join(".");
         const key = this.idKeyMap.get(baseId) ??
             this.normalizeKey(parts.slice(1, parts.length - 1).join("."));
@@ -1307,6 +1318,7 @@ class GiraEndpointAdapter extends utils.Adapter {
             this.clearTimeout(timer);
         }, 1000);
         this.setState(id, { val: ackVal, ack: true });
+        return true;
     }
     handleHsRestartTrigger(id, state) {
         this.log.debug(this.translate("HomeServer restart trigger received (val=%s, ack=%s)", state?.val, state?.ack));

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,6 +82,11 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
     | string;
 }
 
+type ForwardMapping = {
+  key: string;
+  bool: boolean;
+  textEncoding: TextEncoding;
+};
 
 class GiraEndpointAdapter extends utils.Adapter {
   private client?: GiraClient;
@@ -90,7 +95,7 @@ class GiraEndpointAdapter extends utils.Adapter {
   private idKeyMap = new Map<string, string>();
   private keyDescMap = new Map<string, string>();
   private keyCaseMap = new Map<string, string>();
-  private forwardMap = new Map<string, { key: string; bool: boolean; textEncoding: TextEncoding }>();
+  private forwardMap = new Map<string, ForwardMapping>();
   private keyTextEncodingMap = new Map<string, TextEncoding>();
   private reverseMap = new Map<string, { stateId: string; bool: boolean; ack: boolean }>();
   private boolKeys = new Set<string>();
@@ -1334,57 +1339,70 @@ class GiraEndpointAdapter extends utils.Adapter {
     if (!state || !this.client) return;
 
     const mapped = this.forwardMap.get(id);
-    if (mapped) {
-      if (this.suppressStateChange.has(id)) {
-        this.log.debug(
-          this.translate(
-            "Ignoring state change for %s because it was just updated from endpoint",
-            id
-          )
-        );
-        return;
-      }
-      const { uidValue, ackVal, method } = encodeUidValue(state.val, mapped.bool, mapped.textEncoding);
-      this.logOutgoingCoValue({
-        source: "mapping",
-        stateId: id,
-        key: mapped.key,
-        method,
-        ackVal,
-        uidValue,
-        bool: mapped.bool,
-        textEncoding: mapped.textEncoding,
-      });
-      this.client.call(mapped.key, method, uidValue);
-      const baseId =
-        this.keyIdMap.get(mapped.key) ?? this.makeEndpointBaseId(mapped.key);
-      this.keyIdMap.set(mapped.key, baseId);
-      this.idKeyMap.set(baseId, mapped.key);
-      this.setState(`${baseId}.value`, { val: ackVal, ack: true });
-      if (!state.ack) {
-        this.suppressStateChange.add(id);
-        this.setForeignState(id, { val: state.val, ack: true });
-        const supTimer = this.setTimeout(() => {
-          this.suppressStateChange.delete(id);
-          this.clearTimeout(supTimer);
-        }, 1000);
-      }
-      this.pendingUpdates.set(mapped.key, ackVal);
-      const timer = this.setTimeout(() => {
-        this.pendingUpdates.delete(mapped.key);
-        this.clearTimeout(timer);
-      }, 1000);
-      return;
+    if (mapped && this.handleMappedStateChange(id, state, mapped)) return;
+
+    if (this.handleArchiveStateChange(id, state)) return;
+
+    if (this.handleDirectCoStateChange(id, state)) return;
+  }
+
+  private handleMappedStateChange(
+    id: string,
+    state: ioBroker.State,
+    mapped: ForwardMapping
+  ): boolean {
+    if (this.suppressStateChange.has(id)) {
+      this.log.debug(
+        this.translate(
+          "Ignoring state change for %s because it was just updated from endpoint",
+          id
+        )
+      );
+      return true;
     }
+    const { uidValue, ackVal, method } = encodeUidValue(state.val, mapped.bool, mapped.textEncoding);
+    this.logOutgoingCoValue({
+      source: "mapping",
+      stateId: id,
+      key: mapped.key,
+      method,
+      ackVal,
+      uidValue,
+      bool: mapped.bool,
+      textEncoding: mapped.textEncoding,
+    });
+    this.client!.call(mapped.key, method, uidValue);
+    const baseId =
+      this.keyIdMap.get(mapped.key) ?? this.makeEndpointBaseId(mapped.key);
+    this.keyIdMap.set(mapped.key, baseId);
+    this.idKeyMap.set(baseId, mapped.key);
+    this.setState(`${baseId}.value`, { val: ackVal, ack: true });
+    if (!state.ack) {
+      this.suppressStateChange.add(id);
+      this.setForeignState(id, { val: state.val, ack: true });
+      const supTimer = this.setTimeout(() => {
+        this.suppressStateChange.delete(id);
+        this.clearTimeout(supTimer);
+      }, 1000);
+    }
+    this.pendingUpdates.set(mapped.key, ackVal);
+    const timer = this.setTimeout(() => {
+      this.pendingUpdates.delete(mapped.key);
+      this.clearTimeout(timer);
+    }, 1000);
+    return true;
+  }
+
+  private handleArchiveStateChange(id: string, state: ioBroker.State): boolean {
     if (id.startsWith("DA@.")) {
-      if (state.ack) return;
+      if (state.ack) return true;
       const parts = id.split(".");
       const action = parts.pop();
       const baseId = parts.join(".");
       const key = this.archiveIdKeyMap.get(baseId);
-      if (!key || !action) return;
+      if (!key || !action) return true;
       if (action === "meta") {
-        const prom = this.client.call(key, "meta", undefined, this.makeTag("meta"));
+        const prom = this.client!.call(key, "meta", undefined, this.makeTag("meta"));
         if (prom) {
           prom
             .then(async (resp: any) => {
@@ -1414,9 +1432,9 @@ class GiraEndpointAdapter extends utils.Adapter {
           this.log.warn(
             this.translate("Invalid query parameters for %s: %s", id, state.val)
           );
-          return;
+          return true;
         }
-        const prom = this.client.call(key, "get", params, this.makeTag("get"));
+        const prom = this.client!.call(key, "get", params, this.makeTag("get"));
         if (prom) {
           prom
             .then((resp: any) => {
@@ -1437,21 +1455,21 @@ class GiraEndpointAdapter extends utils.Adapter {
             });
         }
       }
-      return;
+      return true;
     }
 
     if (id.startsWith("CO@.")) {
       const parts = id.split(".");
       const action = parts.pop();
       if (action === "meta") {
-        if (state.ack) return;
+        if (state.ack) return true;
         const baseId = parts.join(".");
         const key =
           this.idKeyMap.get(baseId) ??
           this.normalizeKey(parts.slice(1).join("."));
-        if (!key) return;
+        if (!key) return true;
         if (action === "meta") {
-          const prom = this.client.call(key, "meta", undefined, this.makeTag("meta"));
+          const prom = this.client!.call(key, "meta", undefined, this.makeTag("meta"));
           if (prom) {
             prom
               .then(async (resp: any) => {
@@ -1471,15 +1489,19 @@ class GiraEndpointAdapter extends utils.Adapter {
                 );
               });
           }
-          return;
+          return true;
         }
       }
     }
 
-    if (state.ack) return;
-    if (!id.startsWith("CO@.")) return;
+    return false;
+  }
+
+  private handleDirectCoStateChange(id: string, state: ioBroker.State): boolean {
+    if (state.ack) return false;
+    if (!id.startsWith("CO@.")) return false;
     const parts = id.split(".");
-    if (parts[parts.length - 1] !== "value") return;
+    if (parts[parts.length - 1] !== "value") return false;
     const baseId = parts.slice(0, parts.length - 1).join(".");
     const key =
       this.idKeyMap.get(baseId) ??
@@ -1497,7 +1519,7 @@ class GiraEndpointAdapter extends utils.Adapter {
       bool: boolKey,
       textEncoding,
     });
-    this.client.call(key, method, uidValue);
+    this.client!.call(key, method, uidValue);
     const mappedForeign = this.reverseMap.get(key);
     if (mappedForeign) {
       let mappedVal = decodeAckValue(ackVal, mappedForeign.bool).value;
@@ -1520,6 +1542,7 @@ class GiraEndpointAdapter extends utils.Adapter {
       this.clearTimeout(timer);
     }, 1000);
     this.setState(id, { val: ackVal, ack: true });
+    return true;
   }
 
   private handleHsRestartTrigger(

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,5 +1,5 @@
 const assert = require("assert").strict;
-const { encodeUidValue } = require("../build/main");
+const { encodeUidValue, decodeCoValue } = require("../build/lib/valueConversion");
 
 // Cover critical text encoding conversions in the test entrypoint run by npm test.
 assert.equal(
@@ -10,6 +10,19 @@ assert.equal(
   encodeUidValue("Hauptwäsche", false, "latin1").uidValue,
   "SGF1cHR35HNjaGU="
 );
+
+assert.equal(
+  decodeCoValue("SGF1cHR35HNjaGUy", false, "latin1").value,
+  "Hauptwäsche2"
+);
+assert.equal(
+  decodeCoValue("SGF1cHR3w6RzY2hlMg==", false, "utf8").value,
+  "Hauptwäsche2"
+);
+assert.deepStrictEqual(decodeCoValue("123", false, "latin1"), {
+  value: 123,
+  type: "number",
+});
 
 const path = require("path");
 const { tests } = require("@iobroker/testing");


### PR DESCRIPTION
### Motivation
- Tests broke because value-conversion helpers were moved out of `build/main.js` into `build/lib/valueConversion.js`, so the test entrypoint must import the new module path.
- `onStateChange()` was a large monolithic handler that made the control flow hard to follow and should be routed into smaller, single-responsibility handlers without changing behavior.
- Keep adapter runtime behavior, encoding, archive logic and external client usage unchanged while making the code easier to read and type-safe locally.

### Description
- Change test import in `test/main.test.js` to `const { encodeUidValue, decodeCoValue } = require("../build/lib/valueConversion");` and add `decodeCoValue` assertions for latin1, utf8 and numeric values. 
- Split `onStateChange()` in `src/main.ts` into a short router and three private handlers `handleMappedStateChange`, `handleArchiveStateChange` and `handleDirectCoStateChange`, preserving all existing checks (`state.ack`, `suppressStateChange`, `pendingUpdates`, `setState/setForeignState`, logging and encoding behavior). 
- Add a small local type `ForwardMapping` and switch `forwardMap` to `Map<string, ForwardMapping>` for clearer handler signatures. 
- Use non-null assertions for `this.client` when calling inside handlers to keep structural changes minimal and avoid behavioral changes.

### Testing
- Ran `npm run build` which completed successfully. 
- Executed runtime assertions directly against the built helpers with `node` to validate `encodeUidValue` and `decodeCoValue` behavior (latin1, utf8 and numeric decode assertions), and they passed. 
- Ran `npm test` but it could not complete because the test harness dependency `@iobroker/testing` was not installed and `npm install` failed in this environment with a registry `403 Forbidden`, so the integration harness step did not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fb363e1488325a5314101a32b9a62)