### PR TITLE
Extract endpoint and mapping parsing into src/lib/configParser.ts

### DIFF
--- a/build/lib/configParser.js
+++ b/build/lib/configParser.js
@@ -1,0 +1,168 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.parseEndpointAndMappingConfig = parseEndpointAndMappingConfig;
+const valueConversion_1 = require("./valueConversion");
+function rememberKeyCase(keyCaseMap, normalized, original) {
+    if (!normalized)
+        return;
+    const trimmed = String(original ?? "").trim();
+    if (!trimmed)
+        return;
+    const suffix = trimmed.replace(/^CO@/i, "");
+    keyCaseMap.set(normalized, `CO@${suffix}`);
+}
+function sanitizeEndpointId(s) {
+    return s.replace(/^CO@/i, "").replace(/[^a-z0-9@_\-\.]/gi, "_");
+}
+function makeCasePreservedEndpointBaseId(key, keyCaseMap, fallback) {
+    const casedKey = keyCaseMap.get(key);
+    if (!casedKey)
+        return fallback(key);
+    return `CO@.${sanitizeEndpointId(casedKey)}`;
+}
+function parseEndpointAndMappingConfig(cfg, helpers) {
+    const boolKeys = new Set();
+    const skipInitialUpdate = new Set();
+    const updateOnStartSources = [];
+    const keyTextEncodingMap = new Map();
+    const keyDescMap = new Map();
+    const keyCaseMap = new Map();
+    const rawKeys = Array.isArray(cfg.endpointGroups)
+        ? cfg.endpointGroups.flatMap((g) => Array.isArray(g?.keys) ? g.keys : [])
+        : cfg.endpointKeys;
+    const endpointKeys = [];
+    if (Array.isArray(rawKeys)) {
+        for (const k of rawKeys) {
+            if (typeof k === "object" && k) {
+                if (k.enabled === false)
+                    continue;
+                const rawKey = String(k.key ?? "").trim();
+                const key = helpers.normalizeKey(rawKey);
+                if (!key)
+                    continue;
+                rememberKeyCase(keyCaseMap, key, rawKey || key);
+                const name = String(k.name ?? "").trim();
+                if (name)
+                    keyDescMap.set(key, name);
+                const bool = Boolean(k.bool);
+                if (bool)
+                    boolKeys.add(key);
+                const textEncoding = (0, valueConversion_1.normalizeTextEncoding)(k.textEncoding);
+                keyTextEncodingMap.set(key, textEncoding);
+                const updateOnStart = k.updateOnStart !== false;
+                if (!updateOnStart)
+                    skipInitialUpdate.add(key);
+                if (updateOnStart) {
+                    const baseId = makeCasePreservedEndpointBaseId(key, keyCaseMap, helpers.makeEndpointBaseId);
+                    updateOnStartSources.push({
+                        key,
+                        stateId: `${baseId}.value`,
+                        bool,
+                        foreign: false,
+                        textEncoding,
+                    });
+                }
+                endpointKeys.push(key);
+            }
+            else {
+                const rawKey = String(k).trim();
+                const key = helpers.normalizeKey(rawKey);
+                if (!key)
+                    continue;
+                rememberKeyCase(keyCaseMap, key, rawKey || key);
+                endpointKeys.push(key);
+            }
+        }
+    }
+    else {
+        const arr = String(rawKeys ?? "")
+            .split(/[,;\s]+/)
+            .map((k) => k.trim())
+            .filter((k) => k);
+        for (const rawKey of arr) {
+            const key = helpers.normalizeKey(rawKey);
+            if (!key)
+                continue;
+            rememberKeyCase(keyCaseMap, key, rawKey);
+            endpointKeys.push(key);
+        }
+    }
+    const forwardMap = new Map();
+    const reverseMap = new Map();
+    const mappingGroups = Array.isArray(cfg.mappingGroups)
+        ? cfg.mappingGroups
+        : Array.isArray(cfg.mappings)
+            ? [{ mappings: cfg.mappings }]
+            : [];
+    for (const g of mappingGroups) {
+        if (!g || typeof g !== "object")
+            continue;
+        const list = g.mappings;
+        if (!Array.isArray(list))
+            continue;
+        for (const m of list) {
+            if (typeof m !== "object" || !m)
+                continue;
+            if (m.enabled === false)
+                continue;
+            const stateId = String(m.stateId ?? "").trim();
+            const rawKey = String(m.key ?? "").trim();
+            const key = helpers.normalizeKey(rawKey);
+            if (!stateId || !key)
+                continue;
+            rememberKeyCase(keyCaseMap, key, rawKey || key);
+            const name = String(m.name ?? "").trim();
+            if (name)
+                keyDescMap.set(key, name);
+            const toEndpoint = m.toEndpoint !== false;
+            const toState = Boolean(m.toState);
+            const bool = Boolean(m.bool);
+            const ack = m.ack !== false;
+            const textEncoding = (0, valueConversion_1.normalizeTextEncoding)(m.textEncoding);
+            if (!keyTextEncodingMap.has(key)) {
+                keyTextEncodingMap.set(key, textEncoding);
+            }
+            const updateOnStart = m.updateOnStart !== false;
+            if (!updateOnStart)
+                skipInitialUpdate.add(key);
+            if (toEndpoint) {
+                forwardMap.set(stateId, { key, bool, textEncoding });
+                if (bool)
+                    boolKeys.add(key);
+                if (updateOnStart) {
+                    updateOnStartSources.push({
+                        key,
+                        stateId,
+                        bool,
+                        foreign: true,
+                        textEncoding,
+                    });
+                }
+            }
+            if (toState) {
+                reverseMap.set(key, { stateId, bool, ack });
+                if (bool)
+                    boolKeys.add(key);
+            }
+            if (!endpointKeys.includes(key))
+                endpointKeys.push(key);
+        }
+    }
+    const uniqueSources = new Map();
+    for (const src of updateOnStartSources) {
+        const key = `${src.key}|${src.stateId}|${src.foreign ? "1" : "0"}`;
+        if (!uniqueSources.has(key))
+            uniqueSources.set(key, src);
+    }
+    return {
+        endpointKeys,
+        forwardMap,
+        reverseMap,
+        boolKeys,
+        keyTextEncodingMap,
+        keyDescMap,
+        keyCaseMap,
+        skipInitialUpdate,
+        updateOnStartSources: Array.from(uniqueSources.values()),
+    };
+}

--- a/build/main.js
+++ b/build/main.js
@@ -38,6 +38,7 @@ const GiraClient_1 = require("./lib/GiraClient");
 const crypto_1 = require("crypto");
 const util_1 = require("util");
 const valueConversion_1 = require("./lib/valueConversion");
+const configParser_1 = require("./lib/configParser");
 class GiraEndpointAdapter extends utils.Adapter {
     formatLogValue(value, maxLength = 200) {
         let text;
@@ -179,144 +180,20 @@ class GiraEndpointAdapter extends utils.Adapter {
             const password = String(cfg.password ?? "");
             const authHeader = Boolean(cfg.authHeader);
             const pingIntervalMs = Number(cfg.pingIntervalMs ?? 30000);
-            const boolKeys = new Set();
-            const skipInitial = new Set();
-            const updateOnStartSources = [];
-            const keyTextEncodingMap = new Map();
-            this.keyCaseMap.clear();
-            const rawKeys = Array.isArray(cfg.endpointGroups)
-                ? cfg.endpointGroups.flatMap((g) => Array.isArray(g?.keys) ? g.keys : [])
-                : cfg.endpointKeys;
-            const endpointKeys = [];
-            if (Array.isArray(rawKeys)) {
-                for (const k of rawKeys) {
-                    if (typeof k === "object" && k) {
-                        if (k.enabled === false)
-                            continue;
-                        const rawKey = String(k.key ?? "").trim();
-                        const key = this.normalizeKey(rawKey);
-                        if (!key)
-                            continue;
-                        this.rememberKeyCase(key, rawKey || key);
-                        const name = String(k.name ?? "").trim();
-                        if (name)
-                            this.keyDescMap.set(key, name);
-                        const bool = Boolean(k.bool);
-                        if (bool)
-                            boolKeys.add(key);
-                        const textEncoding = (0, valueConversion_1.normalizeTextEncoding)(k.textEncoding);
-                        keyTextEncodingMap.set(key, textEncoding);
-                        const updateOnStart = k.updateOnStart !== false;
-                        if (!updateOnStart)
-                            skipInitial.add(key);
-                        if (updateOnStart) {
-                            const baseId = this.makeEndpointBaseId(key);
-                            updateOnStartSources.push({
-                                key,
-                                stateId: `${baseId}.value`,
-                                bool,
-                                foreign: false,
-                                textEncoding,
-                            });
-                        }
-                        endpointKeys.push(key);
-                    }
-                    else {
-                        const rawKey = String(k).trim();
-                        const key = this.normalizeKey(rawKey);
-                        if (!key)
-                            continue;
-                        this.rememberKeyCase(key, rawKey || key);
-                        endpointKeys.push(key);
-                    }
-                }
-            }
-            else {
-                const arr = String(rawKeys ?? "")
-                    .split(/[,;\s]+/)
-                    .map((k) => k.trim())
-                    .filter((k) => k);
-                for (const rawKey of arr) {
-                    const key = this.normalizeKey(rawKey);
-                    if (!key)
-                        continue;
-                    this.rememberKeyCase(key, rawKey);
-                    endpointKeys.push(key);
-                }
-            }
-            const forwardMap = new Map();
-            const reverseMap = new Map();
-            const mappingGroups = Array.isArray(cfg.mappingGroups)
-                ? cfg.mappingGroups
-                : Array.isArray(cfg.mappings)
-                    ? [{ mappings: cfg.mappings }]
-                    : [];
-            for (const g of mappingGroups) {
-                if (!g || typeof g !== "object")
-                    continue;
-                const list = g.mappings;
-                if (!Array.isArray(list))
-                    continue;
-                for (const m of list) {
-                    if (typeof m !== "object" || !m)
-                        continue;
-                    if (m.enabled === false)
-                        continue;
-                    const stateId = String(m.stateId ?? "").trim();
-                    const rawKey = String(m.key ?? "").trim();
-                    const key = this.normalizeKey(rawKey);
-                    if (!stateId || !key)
-                        continue;
-                    this.rememberKeyCase(key, rawKey || key);
-                    const name = String(m.name ?? "").trim();
-                    if (name)
-                        this.keyDescMap.set(key, name);
-                    const toEndpoint = m.toEndpoint !== false;
-                    const toState = Boolean(m.toState);
-                    const bool = Boolean(m.bool);
-                    const ack = m.ack !== false;
-                    const textEncoding = (0, valueConversion_1.normalizeTextEncoding)(m.textEncoding);
-                    if (!keyTextEncodingMap.has(key)) {
-                        keyTextEncodingMap.set(key, textEncoding);
-                    }
-                    const updateOnStart = m.updateOnStart !== false;
-                    if (!updateOnStart)
-                        skipInitial.add(key);
-                    if (toEndpoint) {
-                        forwardMap.set(stateId, { key, bool, textEncoding });
-                        if (bool)
-                            boolKeys.add(key);
-                        if (updateOnStart) {
-                            updateOnStartSources.push({
-                                key,
-                                stateId,
-                                bool,
-                                foreign: true,
-                                textEncoding,
-                            });
-                        }
-                    }
-                    if (toState) {
-                        reverseMap.set(key, { stateId, bool, ack });
-                        if (bool)
-                            boolKeys.add(key);
-                    }
-                    if (!endpointKeys.includes(key))
-                        endpointKeys.push(key);
-                }
-            }
-            this.forwardMap = forwardMap;
-            this.reverseMap = reverseMap;
-            this.boolKeys = boolKeys;
-            this.skipInitialUpdate = skipInitial;
-            this.initialSkipUpdate = new Set(skipInitial);
-            const uniqueSources = new Map();
-            for (const src of updateOnStartSources) {
-                const key = `${src.key}|${src.stateId}|${src.foreign ? "1" : "0"}`;
-                if (!uniqueSources.has(key))
-                    uniqueSources.set(key, src);
-            }
-            this.updateOnStartSources = Array.from(uniqueSources.values());
+            const parsed = (0, configParser_1.parseEndpointAndMappingConfig)(cfg, {
+                normalizeKey: this.normalizeKey.bind(this),
+                makeEndpointBaseId: this.makeEndpointBaseId.bind(this),
+            });
+            this.forwardMap = parsed.forwardMap;
+            this.reverseMap = parsed.reverseMap;
+            this.boolKeys = parsed.boolKeys;
+            this.keyDescMap = parsed.keyDescMap;
+            this.keyCaseMap = parsed.keyCaseMap;
+            this.skipInitialUpdate = parsed.skipInitialUpdate;
+            this.initialSkipUpdate = new Set(parsed.skipInitialUpdate);
+            this.updateOnStartSources = parsed.updateOnStartSources;
+            this.endpointKeys = parsed.endpointKeys;
+            this.keyTextEncodingMap = parsed.keyTextEncodingMap;
             this.archiveQueryDefaults.clear();
             const rawArchives = cfg.dataArchives;
             const archiveKeys = [];
@@ -373,12 +250,10 @@ class GiraEndpointAdapter extends utils.Adapter {
                     this.archiveDescMap.set(key, key);
             }
             this.archiveKeys = archiveKeys;
-            for (const key of endpointKeys) {
+            for (const key of this.endpointKeys) {
                 if (!this.keyDescMap.has(key))
                     this.keyDescMap.set(key, key);
             }
-            this.endpointKeys = endpointKeys;
-            this.keyTextEncodingMap = keyTextEncodingMap;
             const endpointKeysText = this.endpointKeys.length
                 ? this.endpointKeys.join(", ")
                 : this.translate("(none)");

--- a/src/lib/configParser.ts
+++ b/src/lib/configParser.ts
@@ -1,0 +1,254 @@
+import { normalizeTextEncoding, TextEncoding } from "./valueConversion";
+
+export type AdapterConfigLike = {
+  endpointKeys?:
+    | string[]
+    | {
+        key: string;
+        name?: string;
+        bool?: boolean;
+        updateOnStart?: boolean;
+        enabled?: boolean;
+        textEncoding?: TextEncoding;
+      }[]
+    | string;
+  endpointGroups?: {
+    group?: string;
+    keys: {
+      key: string;
+      name?: string;
+      bool?: boolean;
+      updateOnStart?: boolean;
+      enabled?: boolean;
+      textEncoding?: TextEncoding;
+    }[];
+  }[];
+  mappings?: {
+    stateId: string;
+    key: string;
+    name?: string;
+    toEndpoint?: boolean;
+    toState?: boolean;
+    bool?: boolean;
+    ack?: boolean;
+    updateOnStart?: boolean;
+    enabled?: boolean;
+    textEncoding?: TextEncoding;
+  }[];
+  mappingGroups?: {
+    group?: string;
+    mappings: {
+      stateId: string;
+      key: string;
+      name?: string;
+      toEndpoint?: boolean;
+      toState?: boolean;
+      bool?: boolean;
+      ack?: boolean;
+      updateOnStart?: boolean;
+      enabled?: boolean;
+      textEncoding?: TextEncoding;
+    }[];
+  }[];
+};
+
+export type ForwardMapping = {
+  key: string;
+  bool: boolean;
+  textEncoding: TextEncoding;
+};
+
+export type ReverseMapping = {
+  stateId: string;
+  bool: boolean;
+  ack: boolean;
+};
+
+export type UpdateOnStartSource = {
+  key: string;
+  stateId: string;
+  bool: boolean;
+  foreign: boolean;
+  textEncoding: TextEncoding;
+};
+
+export type ParsedEndpointMappingConfig = {
+  endpointKeys: string[];
+  forwardMap: Map<string, ForwardMapping>;
+  reverseMap: Map<string, ReverseMapping>;
+  boolKeys: Set<string>;
+  keyTextEncodingMap: Map<string, TextEncoding>;
+  keyDescMap: Map<string, string>;
+  keyCaseMap: Map<string, string>;
+  skipInitialUpdate: Set<string>;
+  updateOnStartSources: UpdateOnStartSource[];
+};
+
+function rememberKeyCase(
+  keyCaseMap: Map<string, string>,
+  normalized: string,
+  original: string
+): void {
+  if (!normalized) return;
+  const trimmed = String(original ?? "").trim();
+  if (!trimmed) return;
+  const suffix = trimmed.replace(/^CO@/i, "");
+  keyCaseMap.set(normalized, `CO@${suffix}`);
+}
+
+function sanitizeEndpointId(s: string): string {
+  return s.replace(/^CO@/i, "").replace(/[^a-z0-9@_\-\.]/gi, "_");
+}
+
+function makeCasePreservedEndpointBaseId(
+  key: string,
+  keyCaseMap: Map<string, string>,
+  fallback: (key: string) => string
+): string {
+  const casedKey = keyCaseMap.get(key);
+  if (!casedKey) return fallback(key);
+  return `CO@.${sanitizeEndpointId(casedKey)}`;
+}
+
+export function parseEndpointAndMappingConfig(
+  cfg: AdapterConfigLike,
+  helpers: {
+    normalizeKey: (rawKey: string) => string;
+    makeEndpointBaseId: (key: string) => string;
+  }
+): ParsedEndpointMappingConfig {
+  const boolKeys = new Set<string>();
+  const skipInitialUpdate = new Set<string>();
+  const updateOnStartSources: UpdateOnStartSource[] = [];
+  const keyTextEncodingMap = new Map<string, TextEncoding>();
+  const keyDescMap = new Map<string, string>();
+  const keyCaseMap = new Map<string, string>();
+
+  const rawKeys = Array.isArray(cfg.endpointGroups)
+    ? cfg.endpointGroups.flatMap((g: any) =>
+        Array.isArray(g?.keys) ? g.keys : []
+      )
+    : cfg.endpointKeys;
+  const endpointKeys: string[] = [];
+  if (Array.isArray(rawKeys)) {
+    for (const k of rawKeys) {
+      if (typeof k === "object" && k) {
+        if ((k as any).enabled === false) continue;
+        const rawKey = String((k as any).key ?? "").trim();
+        const key = helpers.normalizeKey(rawKey);
+        if (!key) continue;
+        rememberKeyCase(keyCaseMap, key, rawKey || key);
+        const name = String((k as any).name ?? "").trim();
+        if (name) keyDescMap.set(key, name);
+        const bool = Boolean((k as any).bool);
+        if (bool) boolKeys.add(key);
+        const textEncoding = normalizeTextEncoding((k as any).textEncoding);
+        keyTextEncodingMap.set(key, textEncoding);
+        const updateOnStart = (k as any).updateOnStart !== false;
+        if (!updateOnStart) skipInitialUpdate.add(key);
+        if (updateOnStart) {
+          const baseId = makeCasePreservedEndpointBaseId(
+            key,
+            keyCaseMap,
+            helpers.makeEndpointBaseId
+          );
+          updateOnStartSources.push({
+            key,
+            stateId: `${baseId}.value`,
+            bool,
+            foreign: false,
+            textEncoding,
+          });
+        }
+        endpointKeys.push(key);
+      } else {
+        const rawKey = String(k).trim();
+        const key = helpers.normalizeKey(rawKey);
+        if (!key) continue;
+        rememberKeyCase(keyCaseMap, key, rawKey || key);
+        endpointKeys.push(key);
+      }
+    }
+  } else {
+    const arr = String(rawKeys ?? "")
+      .split(/[,;\s]+/)
+      .map((k) => k.trim())
+      .filter((k) => k);
+    for (const rawKey of arr) {
+      const key = helpers.normalizeKey(rawKey);
+      if (!key) continue;
+      rememberKeyCase(keyCaseMap, key, rawKey);
+      endpointKeys.push(key);
+    }
+  }
+
+  const forwardMap = new Map<string, ForwardMapping>();
+  const reverseMap = new Map<string, ReverseMapping>();
+  const mappingGroups = Array.isArray(cfg.mappingGroups)
+    ? cfg.mappingGroups
+    : Array.isArray(cfg.mappings)
+    ? [{ mappings: cfg.mappings }]
+    : [];
+  for (const g of mappingGroups) {
+    if (!g || typeof g !== "object") continue;
+    const list = (g as any).mappings;
+    if (!Array.isArray(list)) continue;
+    for (const m of list) {
+      if (typeof m !== "object" || !m) continue;
+      if ((m as any).enabled === false) continue;
+      const stateId = String((m as any).stateId ?? "").trim();
+      const rawKey = String((m as any).key ?? "").trim();
+      const key = helpers.normalizeKey(rawKey);
+      if (!stateId || !key) continue;
+      rememberKeyCase(keyCaseMap, key, rawKey || key);
+      const name = String((m as any).name ?? "").trim();
+      if (name) keyDescMap.set(key, name);
+      const toEndpoint = (m as any).toEndpoint !== false;
+      const toState = Boolean((m as any).toState);
+      const bool = Boolean((m as any).bool);
+      const ack = (m as any).ack !== false;
+      const textEncoding = normalizeTextEncoding((m as any).textEncoding);
+      if (!keyTextEncodingMap.has(key)) {
+        keyTextEncodingMap.set(key, textEncoding);
+      }
+      const updateOnStart = (m as any).updateOnStart !== false;
+      if (!updateOnStart) skipInitialUpdate.add(key);
+      if (toEndpoint) {
+        forwardMap.set(stateId, { key, bool, textEncoding });
+        if (bool) boolKeys.add(key);
+        if (updateOnStart) {
+          updateOnStartSources.push({
+            key,
+            stateId,
+            bool,
+            foreign: true,
+            textEncoding,
+          });
+        }
+      }
+      if (toState) {
+        reverseMap.set(key, { stateId, bool, ack });
+        if (bool) boolKeys.add(key);
+      }
+      if (!endpointKeys.includes(key)) endpointKeys.push(key);
+    }
+  }
+
+  const uniqueSources = new Map<string, UpdateOnStartSource>();
+  for (const src of updateOnStartSources) {
+    const key = `${src.key}|${src.stateId}|${src.foreign ? "1" : "0"}`;
+    if (!uniqueSources.has(key)) uniqueSources.set(key, src);
+  }
+
+  return {
+    endpointKeys,
+    forwardMap,
+    reverseMap,
+    boolKeys,
+    keyTextEncodingMap,
+    keyDescMap,
+    keyCaseMap,
+    skipInitialUpdate,
+    updateOnStartSources: Array.from(uniqueSources.values()),
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,8 @@ import * as utils from "@iobroker/adapter-core";
 import { GiraClient, codeToMessage } from "./lib/GiraClient";
 import { randomUUID } from "crypto";
 import { format } from "util";
-import { decodeAckValue, decodeCoValue, encodeUidValue, normalizeTextEncoding, TextEncoding } from "./lib/valueConversion";
+import { decodeAckValue, decodeCoValue, encodeUidValue, TextEncoding } from "./lib/valueConversion";
+import { parseEndpointAndMappingConfig, ForwardMapping, ReverseMapping, UpdateOnStartSource } from "./lib/configParser";
 
 // Configuration options provided by ioBroker's admin interface
 // (extend as needed when more options are supported)
@@ -82,11 +83,6 @@ interface AdapterConfig extends ioBroker.AdapterConfig {
     | string;
 }
 
-type ForwardMapping = {
-  key: string;
-  bool: boolean;
-  textEncoding: TextEncoding;
-};
 
 class GiraEndpointAdapter extends utils.Adapter {
   private client?: GiraClient;
@@ -97,19 +93,13 @@ class GiraEndpointAdapter extends utils.Adapter {
   private keyCaseMap = new Map<string, string>();
   private forwardMap = new Map<string, ForwardMapping>();
   private keyTextEncodingMap = new Map<string, TextEncoding>();
-  private reverseMap = new Map<string, { stateId: string; bool: boolean; ack: boolean }>();
+  private reverseMap = new Map<string, ReverseMapping>();
   private boolKeys = new Set<string>();
   private suppressStateChange = new Set<string>();
   private pendingUpdates = new Map<string, any>();
   private skipInitialUpdate = new Set<string>();
   private initialSkipUpdate = new Set<string>();
-  private updateOnStartSources: Array<{
-    key: string;
-    stateId: string;
-    bool: boolean;
-    foreign: boolean;
-    textEncoding: TextEncoding;
-  }> = [];
+  private updateOnStartSources: UpdateOnStartSource[] = [];
   private pendingSubscriptions = new Set<string>();
   private isConnected = false;
   private pendingHsRestart = false;
@@ -251,7 +241,7 @@ class GiraEndpointAdapter extends utils.Adapter {
         native: {},
       });
 
-        const cfg = this.config as unknown as AdapterConfig;
+      const cfg = this.config as unknown as AdapterConfig;
       const host = String(cfg.host ?? "").trim();
       const port = Number(cfg.port ?? 80);
       const ssl = Boolean(cfg.ssl ?? false);
@@ -261,144 +251,21 @@ class GiraEndpointAdapter extends utils.Adapter {
       const authHeader = Boolean(cfg.authHeader);
       const pingIntervalMs = Number(cfg.pingIntervalMs ?? 30000);
 
-      const boolKeys = new Set<string>();
-      const skipInitial = new Set<string>();
-      const updateOnStartSources: Array<{
-        key: string;
-        stateId: string;
-        bool: boolean;
-        foreign: boolean;
-        textEncoding: TextEncoding;
-      }> = [];
-      const keyTextEncodingMap = new Map<string, TextEncoding>();
+      const parsed = parseEndpointAndMappingConfig(cfg, {
+        normalizeKey: this.normalizeKey.bind(this),
+        makeEndpointBaseId: this.makeEndpointBaseId.bind(this),
+      });
+      this.forwardMap = parsed.forwardMap;
+      this.reverseMap = parsed.reverseMap;
+      this.boolKeys = parsed.boolKeys;
+      this.keyDescMap = parsed.keyDescMap;
+      this.keyCaseMap = parsed.keyCaseMap;
+      this.skipInitialUpdate = parsed.skipInitialUpdate;
+      this.initialSkipUpdate = new Set(parsed.skipInitialUpdate);
+      this.updateOnStartSources = parsed.updateOnStartSources;
+      this.endpointKeys = parsed.endpointKeys;
+      this.keyTextEncodingMap = parsed.keyTextEncodingMap;
 
-      this.keyCaseMap.clear();
-
-      const rawKeys = Array.isArray(cfg.endpointGroups)
-        ? cfg.endpointGroups.flatMap((g: any) =>
-            Array.isArray(g?.keys) ? g.keys : []
-          )
-        : cfg.endpointKeys;
-      const endpointKeys: string[] = [];
-      if (Array.isArray(rawKeys)) {
-        for (const k of rawKeys) {
-          if (typeof k === "object" && k) {
-            if ((k as any).enabled === false) continue;
-            const rawKey = String((k as any).key ?? "").trim();
-            const key = this.normalizeKey(rawKey);
-            if (!key) continue;
-            this.rememberKeyCase(key, rawKey || key);
-            const name = String((k as any).name ?? "").trim();
-            if (name) this.keyDescMap.set(key, name);
-            const bool = Boolean((k as any).bool);
-            if (bool) boolKeys.add(key);
-            const textEncoding = normalizeTextEncoding((k as any).textEncoding);
-            keyTextEncodingMap.set(key, textEncoding);
-            const updateOnStart = (k as any).updateOnStart !== false;
-            if (!updateOnStart) skipInitial.add(key);
-            if (updateOnStart) {
-              const baseId = this.makeEndpointBaseId(key);
-              updateOnStartSources.push({
-                key,
-                stateId: `${baseId}.value`,
-                bool,
-                foreign: false,
-                textEncoding,
-              });
-            }
-            endpointKeys.push(key);
-          } else {
-            const rawKey = String(k).trim();
-            const key = this.normalizeKey(rawKey);
-            if (!key) continue;
-            this.rememberKeyCase(key, rawKey || key);
-            endpointKeys.push(key);
-          }
-        }
-      } else {
-        const arr = String(rawKeys ?? "")
-          .split(/[,;\s]+/)
-          .map((k) => k.trim())
-          .filter((k) => k);
-        for (const rawKey of arr) {
-          const key = this.normalizeKey(rawKey);
-          if (!key) continue;
-          this.rememberKeyCase(key, rawKey);
-          endpointKeys.push(key);
-        }
-      }
-
-      const forwardMap = new Map<string, { key: string; bool: boolean; textEncoding: TextEncoding }>();
-      const reverseMap = new Map<string, { stateId: string; bool: boolean; ack: boolean }>();
-      const mappingGroups = Array.isArray(cfg.mappingGroups)
-        ? cfg.mappingGroups
-        : Array.isArray(cfg.mappings)
-        ? [{ mappings: cfg.mappings }]
-        : [];
-      for (const g of mappingGroups) {
-        if (!g || typeof g !== "object") continue;
-        const list = (g as any).mappings;
-        if (!Array.isArray(list)) continue;
-        for (const m of list) {
-          if (typeof m !== "object" || !m) continue;
-          if ((m as any).enabled === false) continue;
-          const stateId = String((m as any).stateId ?? "").trim();
-          const rawKey = String((m as any).key ?? "").trim();
-          const key = this.normalizeKey(rawKey);
-          if (!stateId || !key) continue;
-          this.rememberKeyCase(key, rawKey || key);
-          const name = String((m as any).name ?? "").trim();
-          if (name) this.keyDescMap.set(key, name);
-          const toEndpoint = (m as any).toEndpoint !== false;
-          const toState = Boolean((m as any).toState);
-          const bool = Boolean((m as any).bool);
-          const ack = (m as any).ack !== false;
-          const textEncoding = normalizeTextEncoding((m as any).textEncoding);
-          if (!keyTextEncodingMap.has(key)) {
-            keyTextEncodingMap.set(key, textEncoding);
-          }
-          const updateOnStart = (m as any).updateOnStart !== false;
-          if (!updateOnStart) skipInitial.add(key);
-          if (toEndpoint) {
-            forwardMap.set(stateId, { key, bool, textEncoding });
-            if (bool) boolKeys.add(key);
-            if (updateOnStart) {
-              updateOnStartSources.push({
-                key,
-                stateId,
-                bool,
-                foreign: true,
-                textEncoding,
-              });
-            }
-          }
-          if (toState) {
-            reverseMap.set(key, { stateId, bool, ack });
-            if (bool) boolKeys.add(key);
-          }
-          if (!endpointKeys.includes(key)) endpointKeys.push(key);
-        }
-      }
-      this.forwardMap = forwardMap;
-      this.reverseMap = reverseMap;
-      this.boolKeys = boolKeys;
-      this.skipInitialUpdate = skipInitial;
-      this.initialSkipUpdate = new Set(skipInitial);
-      const uniqueSources = new Map<
-        string,
-        {
-          key: string;
-          stateId: string;
-          bool: boolean;
-          foreign: boolean;
-          textEncoding: TextEncoding;
-        }
-      >();
-      for (const src of updateOnStartSources) {
-        const key = `${src.key}|${src.stateId}|${src.foreign ? "1" : "0"}`;
-        if (!uniqueSources.has(key)) uniqueSources.set(key, src);
-      }
-      this.updateOnStartSources = Array.from(uniqueSources.values());
       this.archiveQueryDefaults.clear();
       const rawArchives = cfg.dataArchives;
       const archiveKeys: string[] = [];
@@ -446,11 +313,9 @@ class GiraEndpointAdapter extends utils.Adapter {
       }
       this.archiveKeys = archiveKeys;
 
-      for (const key of endpointKeys) {
+      for (const key of this.endpointKeys) {
         if (!this.keyDescMap.has(key)) this.keyDescMap.set(key, key);
       }
-      this.endpointKeys = endpointKeys;
-      this.keyTextEncodingMap = keyTextEncodingMap;
 
       const endpointKeysText = this.endpointKeys.length
         ? this.endpointKeys.join(", ")


### PR DESCRIPTION
### Motivation
- Reduce the size and complexity of `onReady()` by moving endpoint key and mapping-group parsing into a dedicated parser module without changing runtime behavior.
- Keep archive parsing, `GiraClient` creation, object/state setup, event/state handlers and encoding/decoding logic untouched.

### Description
- Add `src/lib/configParser.ts` which exports `parseEndpointAndMappingConfig(cfg, helpers)` and small types `ForwardMapping`, `ReverseMapping`, `UpdateOnStartSource`, and `ParsedEndpointMappingConfig` used by the adapter.
- `parseEndpointAndMappingConfig` implements the exact parsing logic previously in `onReady()`: it produces `endpointKeys`, `forwardMap`, `reverseMap`, `boolKeys`, `keyTextEncodingMap`, `keyDescMap`, `keyCaseMap`, `skipInitialUpdate`, and de-duplicated `updateOnStartSources` (dedupe key is `key|stateId|foreign`).
- The parser respects original behavior: `endpointGroups` preferred over legacy `endpointKeys`, `mappingGroups` preferred over legacy `mappings`, `enabled === false` entries are skipped, `bool` flags and `key` casing/descriptions are preserved, and `normalizeTextEncoding()` is used for text encoding handling.
- Update `src/main.ts` so `onReady()` now calls `parseEndpointAndMappingConfig(cfg, { normalizeKey: ..., makeEndpointBaseId: ... })` and assigns returned Maps/Sets/arrays to adapter fields; all archive parsing and client/event wiring remain in `main.ts`.

### Testing
- Ran `npm run build` which completed successfully.
- Ran `npm test` which failed in this environment due to a missing dev dependency (`Error: Cannot find module '@iobroker/testing'`).
- Performed manual parser checks by invoking the built parser with a small `node` script exercising direct endpoint keys, `endpointGroups`, legacy `mappings`, `mappingGroups`, `latin1` textEncoding behavior and update-on-start duplicate handling, and those assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5089ba27248325934d783221ca7b8b)