### PR TITLE
Centralize adapter config parsing: add `parseAdapterConfig` (connection + archives)

### DIFF
--- a/build/lib/configParser.js
+++ b/build/lib/configParser.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.parseEndpointAndMappingConfig = parseEndpointAndMappingConfig;
+exports.parseAdapterConfig = parseAdapterConfig;
 const valueConversion_1 = require("./valueConversion");
 function rememberKeyCase(keyCaseMap, normalized, original) {
     if (!normalized)
@@ -164,5 +165,87 @@ function parseEndpointAndMappingConfig(cfg, helpers) {
         keyCaseMap,
         skipInitialUpdate,
         updateOnStartSources: Array.from(uniqueSources.values()),
+    };
+}
+function parseArchiveConfig(cfg, helpers) {
+    const archiveDescMap = new Map();
+    const archiveQueryDefaults = new Map();
+    const rawArchives = cfg.dataArchives;
+    const archiveKeys = [];
+    if (Array.isArray(rawArchives)) {
+        for (const a of rawArchives) {
+            if (typeof a === "object" && a) {
+                if (a.enabled === false)
+                    continue;
+                const key = helpers.normalizeArchiveKey(String(a.key ?? "").trim());
+                if (!key)
+                    continue;
+                const name = String(a.name ?? "").trim();
+                if (name)
+                    archiveDescMap.set(key, name);
+                const start = String(a.start ?? "").trim();
+                const end = String(a.end ?? "").trim();
+                let cols = a.columns;
+                if (typeof cols === "string") {
+                    cols = cols
+                        .split(/[,;\s]+/)
+                        .map((c) => c.trim())
+                        .filter((c) => c);
+                }
+                const params = {};
+                if (start)
+                    params.from = start;
+                if (end)
+                    params.to = end;
+                if (Array.isArray(cols) && cols.length)
+                    params.columns = cols;
+                if (Object.keys(params).length) {
+                    archiveQueryDefaults.set(key, params);
+                }
+                archiveKeys.push(key);
+            }
+            else {
+                const key = helpers.normalizeArchiveKey(String(a).trim());
+                if (!key)
+                    continue;
+                archiveKeys.push(key);
+            }
+        }
+    }
+    else {
+        const arr = String(rawArchives ?? "")
+            .split(/[,;\s]+/)
+            .map((k) => k.trim())
+            .filter((k) => k)
+            .map((k) => helpers.normalizeArchiveKey(k));
+        archiveKeys.push(...arr);
+    }
+    for (const key of archiveKeys) {
+        if (!archiveDescMap.has(key))
+            archiveDescMap.set(key, key);
+    }
+    return { archiveKeys, archiveDescMap, archiveQueryDefaults };
+}
+function parseAdapterConfig(cfg, helpers) {
+    const endpointMapping = parseEndpointAndMappingConfig(cfg, helpers);
+    const archiveConfig = parseArchiveConfig(cfg, helpers);
+    return {
+        ...endpointMapping,
+        ...archiveConfig,
+        connection: {
+            host: String(cfg.host ?? "").trim(),
+            port: Number(cfg.port ?? 80),
+            ssl: Boolean(cfg.ssl ?? false),
+            path: "/endpoints/ws",
+            username: String(cfg.username ?? ""),
+            password: String(cfg.password ?? ""),
+            authHeader: Boolean(cfg.authHeader),
+            pingIntervalMs: Number(cfg.pingIntervalMs ?? 30000),
+            reconnect: cfg.reconnect,
+            ca: cfg.ca,
+            cert: cfg.cert,
+            key: cfg.key,
+            rejectUnauthorized: cfg.rejectUnauthorized,
+        },
     };
 }

--- a/build/main.js
+++ b/build/main.js
@@ -172,18 +172,12 @@ class GiraEndpointAdapter extends utils.Adapter {
                 native: {},
             });
             const cfg = this.config;
-            const host = String(cfg.host ?? "").trim();
-            const port = Number(cfg.port ?? 80);
-            const ssl = Boolean(cfg.ssl ?? false);
-            const path = "/endpoints/ws";
-            const username = String(cfg.username ?? "");
-            const password = String(cfg.password ?? "");
-            const authHeader = Boolean(cfg.authHeader);
-            const pingIntervalMs = Number(cfg.pingIntervalMs ?? 30000);
-            const parsed = (0, configParser_1.parseEndpointAndMappingConfig)(cfg, {
+            const parsed = (0, configParser_1.parseAdapterConfig)(cfg, {
                 normalizeKey: this.normalizeKey.bind(this),
+                normalizeArchiveKey: this.normalizeArchiveKey.bind(this),
                 makeEndpointBaseId: this.makeEndpointBaseId.bind(this),
             });
+            const { host, port, ssl, path, username, password, authHeader, pingIntervalMs, reconnect, ca, cert, key, rejectUnauthorized, } = parsed.connection;
             this.forwardMap = parsed.forwardMap;
             this.reverseMap = parsed.reverseMap;
             this.boolKeys = parsed.boolKeys;
@@ -194,62 +188,9 @@ class GiraEndpointAdapter extends utils.Adapter {
             this.updateOnStartSources = parsed.updateOnStartSources;
             this.endpointKeys = parsed.endpointKeys;
             this.keyTextEncodingMap = parsed.keyTextEncodingMap;
-            this.archiveQueryDefaults.clear();
-            const rawArchives = cfg.dataArchives;
-            const archiveKeys = [];
-            if (Array.isArray(rawArchives)) {
-                for (const a of rawArchives) {
-                    if (typeof a === "object" && a) {
-                        if (a.enabled === false)
-                            continue;
-                        const key = this.normalizeArchiveKey(String(a.key ?? "").trim());
-                        if (!key)
-                            continue;
-                        const name = String(a.name ?? "").trim();
-                        if (name)
-                            this.archiveDescMap.set(key, name);
-                        const start = String(a.start ?? "").trim();
-                        const end = String(a.end ?? "").trim();
-                        let cols = a.columns;
-                        if (typeof cols === "string") {
-                            cols = cols
-                                .split(/[,;\s]+/)
-                                .map((c) => c.trim())
-                                .filter((c) => c);
-                        }
-                        const params = {};
-                        if (start)
-                            params.from = start;
-                        if (end)
-                            params.to = end;
-                        if (Array.isArray(cols) && cols.length)
-                            params.columns = cols;
-                        if (Object.keys(params).length) {
-                            this.archiveQueryDefaults.set(key, params);
-                        }
-                        archiveKeys.push(key);
-                    }
-                    else {
-                        const key = this.normalizeArchiveKey(String(a).trim());
-                        if (!key)
-                            continue;
-                        archiveKeys.push(key);
-                    }
-                }
-            }
-            else {
-                const arr = String(rawArchives ?? "")
-                    .split(/[,;\s]+/)
-                    .map((k) => k.trim())
-                    .filter((k) => k)
-                    .map((k) => this.normalizeArchiveKey(k));
-                archiveKeys.push(...arr);
-            }
-            for (const key of archiveKeys) {
-                if (!this.archiveDescMap.has(key))
-                    this.archiveDescMap.set(key, key);
-            }
-            this.archiveKeys = archiveKeys;
+            this.archiveKeys = parsed.archiveKeys;
+            this.archiveDescMap = parsed.archiveDescMap;
+            this.archiveQueryDefaults = parsed.archiveQueryDefaults;
             for (const key of this.endpointKeys) {
                 if (!this.keyDescMap.has(key))
                     this.keyDescMap.set(key, key);
@@ -428,11 +369,14 @@ class GiraEndpointAdapter extends utils.Adapter {
             catch {
                 /* ignore */
             }
-            const ca = cfg.ca ? String(cfg.ca) : undefined;
-            const cert = cfg.cert ? String(cfg.cert) : undefined;
-            const key = cfg.key ? String(cfg.key) : undefined;
-            const rejectUnauthorized = cfg.rejectUnauthorized !== undefined ? Boolean(cfg.rejectUnauthorized) : undefined;
-            const tls = { ca, cert, key, rejectUnauthorized };
+            const tls = {
+                ca: ca ? String(ca) : undefined,
+                cert: cert ? String(cert) : undefined,
+                key: key ? String(key) : undefined,
+                rejectUnauthorized: rejectUnauthorized !== undefined
+                    ? Boolean(rejectUnauthorized)
+                    : undefined,
+            };
             // Instantiate client once with all relevant options
             this.client = new GiraClient_1.GiraClient({
                 host,
@@ -444,8 +388,8 @@ class GiraEndpointAdapter extends utils.Adapter {
                 authHeader,
                 pingIntervalMs,
                 reconnect: {
-                    minMs: cfg.reconnect?.minMs ?? 1000,
-                    maxMs: cfg.reconnect?.maxMs ?? 30000,
+                    minMs: reconnect?.minMs ?? 1000,
+                    maxMs: reconnect?.maxMs ?? 30000,
                 },
                 tls,
             });

--- a/src/lib/configParser.ts
+++ b/src/lib/configParser.ts
@@ -1,6 +1,18 @@
 import { normalizeTextEncoding, TextEncoding } from "./valueConversion";
 
 export type AdapterConfigLike = {
+  host?: string;
+  port?: number;
+  ssl?: boolean;
+  username?: string;
+  password?: string;
+  authHeader?: boolean;
+  pingIntervalMs?: number;
+  reconnect?: { minMs?: number; maxMs?: number };
+  ca?: string;
+  cert?: string;
+  key?: string;
+  rejectUnauthorized?: boolean;
   endpointKeys?:
     | string[]
     | {
@@ -50,6 +62,52 @@ export type AdapterConfigLike = {
       textEncoding?: TextEncoding;
     }[];
   }[];
+  dataArchives?:
+    | string[]
+    | {
+        key: string;
+        name?: string;
+        start?: string;
+        end?: string;
+        columns?: string[] | string;
+        enabled?: boolean;
+      }[]
+    | string;
+};
+
+export type ConnectionConfig = {
+  host: string;
+  port: number;
+  ssl: boolean;
+  path: string;
+  username: string;
+  password: string;
+  authHeader: boolean;
+  pingIntervalMs: number;
+  reconnect?: { minMs?: number; maxMs?: number };
+  ca?: string;
+  cert?: string;
+  key?: string;
+  rejectUnauthorized?: boolean;
+};
+
+export type ArchiveQueryDefaults = {
+  from?: string;
+  to?: string;
+  columns?: string[];
+};
+
+export type ParsedAdapterConfig = ParsedEndpointMappingConfig & {
+  connection: ConnectionConfig;
+  archiveKeys: string[];
+  archiveDescMap: Map<string, string>;
+  archiveQueryDefaults: Map<string, ArchiveQueryDefaults>;
+};
+
+export type ConfigParserHelpers = {
+  normalizeKey: (rawKey: string) => string;
+  normalizeArchiveKey: (rawKey: string) => string;
+  makeEndpointBaseId: (key: string) => string;
 };
 
 export type ForwardMapping = {
@@ -250,5 +308,87 @@ export function parseEndpointAndMappingConfig(
     keyCaseMap,
     skipInitialUpdate,
     updateOnStartSources: Array.from(uniqueSources.values()),
+  };
+}
+
+
+function parseArchiveConfig(
+  cfg: AdapterConfigLike,
+  helpers: Pick<ConfigParserHelpers, "normalizeArchiveKey">
+): Pick<ParsedAdapterConfig, "archiveKeys" | "archiveDescMap" | "archiveQueryDefaults"> {
+  const archiveDescMap = new Map<string, string>();
+  const archiveQueryDefaults = new Map<string, ArchiveQueryDefaults>();
+  const rawArchives = cfg.dataArchives;
+  const archiveKeys: string[] = [];
+  if (Array.isArray(rawArchives)) {
+    for (const a of rawArchives) {
+      if (typeof a === "object" && a) {
+        if ((a as any).enabled === false) continue;
+        const key = helpers.normalizeArchiveKey(String((a as any).key ?? "").trim());
+        if (!key) continue;
+        const name = String((a as any).name ?? "").trim();
+        if (name) archiveDescMap.set(key, name);
+        const start = String((a as any).start ?? "").trim();
+        const end = String((a as any).end ?? "").trim();
+        let cols: any = (a as any).columns;
+        if (typeof cols === "string") {
+          cols = cols
+            .split(/[,;\s]+/)
+            .map((c: string) => c.trim())
+            .filter((c: string) => c);
+        }
+        const params: ArchiveQueryDefaults = {};
+        if (start) params.from = start;
+        if (end) params.to = end;
+        if (Array.isArray(cols) && cols.length) params.columns = cols;
+        if (Object.keys(params).length) {
+          archiveQueryDefaults.set(key, params);
+        }
+        archiveKeys.push(key);
+      } else {
+        const key = helpers.normalizeArchiveKey(String(a).trim());
+        if (!key) continue;
+        archiveKeys.push(key);
+      }
+    }
+  } else {
+    const arr = String(rawArchives ?? "")
+      .split(/[,;\s]+/)
+      .map((k) => k.trim())
+      .filter((k) => k)
+      .map((k) => helpers.normalizeArchiveKey(k));
+    archiveKeys.push(...arr);
+  }
+  for (const key of archiveKeys) {
+    if (!archiveDescMap.has(key)) archiveDescMap.set(key, key);
+  }
+  return { archiveKeys, archiveDescMap, archiveQueryDefaults };
+}
+
+export function parseAdapterConfig(
+  cfg: AdapterConfigLike,
+  helpers: ConfigParserHelpers
+): ParsedAdapterConfig {
+  const endpointMapping = parseEndpointAndMappingConfig(cfg, helpers);
+  const archiveConfig = parseArchiveConfig(cfg, helpers);
+
+  return {
+    ...endpointMapping,
+    ...archiveConfig,
+    connection: {
+      host: String(cfg.host ?? "").trim(),
+      port: Number(cfg.port ?? 80),
+      ssl: Boolean(cfg.ssl ?? false),
+      path: "/endpoints/ws",
+      username: String(cfg.username ?? ""),
+      password: String(cfg.password ?? ""),
+      authHeader: Boolean(cfg.authHeader),
+      pingIntervalMs: Number(cfg.pingIntervalMs ?? 30000),
+      reconnect: cfg.reconnect,
+      ca: cfg.ca,
+      cert: cfg.cert,
+      key: cfg.key,
+      rejectUnauthorized: cfg.rejectUnauthorized,
+    },
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { GiraClient, codeToMessage } from "./lib/GiraClient";
 import { randomUUID } from "crypto";
 import { format } from "util";
 import { decodeAckValue, decodeCoValue, encodeUidValue, TextEncoding } from "./lib/valueConversion";
-import { parseEndpointAndMappingConfig, ForwardMapping, ReverseMapping, UpdateOnStartSource } from "./lib/configParser";
+import { parseAdapterConfig, ForwardMapping, ReverseMapping, UpdateOnStartSource } from "./lib/configParser";
 
 // Configuration options provided by ioBroker's admin interface
 // (extend as needed when more options are supported)
@@ -242,19 +242,27 @@ class GiraEndpointAdapter extends utils.Adapter {
       });
 
       const cfg = this.config as unknown as AdapterConfig;
-      const host = String(cfg.host ?? "").trim();
-      const port = Number(cfg.port ?? 80);
-      const ssl = Boolean(cfg.ssl ?? false);
-      const path = "/endpoints/ws";
-      const username = String(cfg.username ?? "");
-      const password = String(cfg.password ?? "");
-      const authHeader = Boolean(cfg.authHeader);
-      const pingIntervalMs = Number(cfg.pingIntervalMs ?? 30000);
-
-      const parsed = parseEndpointAndMappingConfig(cfg, {
+      const parsed = parseAdapterConfig(cfg, {
         normalizeKey: this.normalizeKey.bind(this),
+        normalizeArchiveKey: this.normalizeArchiveKey.bind(this),
         makeEndpointBaseId: this.makeEndpointBaseId.bind(this),
       });
+      const {
+        host,
+        port,
+        ssl,
+        path,
+        username,
+        password,
+        authHeader,
+        pingIntervalMs,
+        reconnect,
+        ca,
+        cert,
+        key,
+        rejectUnauthorized,
+      } = parsed.connection;
+
       this.forwardMap = parsed.forwardMap;
       this.reverseMap = parsed.reverseMap;
       this.boolKeys = parsed.boolKeys;
@@ -266,52 +274,9 @@ class GiraEndpointAdapter extends utils.Adapter {
       this.endpointKeys = parsed.endpointKeys;
       this.keyTextEncodingMap = parsed.keyTextEncodingMap;
 
-      this.archiveQueryDefaults.clear();
-      const rawArchives = cfg.dataArchives;
-      const archiveKeys: string[] = [];
-      if (Array.isArray(rawArchives)) {
-        for (const a of rawArchives) {
-          if (typeof a === "object" && a) {
-            if ((a as any).enabled === false) continue;
-            const key = this.normalizeArchiveKey(String((a as any).key ?? "").trim());
-            if (!key) continue;
-            const name = String((a as any).name ?? "").trim();
-            if (name) this.archiveDescMap.set(key, name);
-            const start = String((a as any).start ?? "").trim();
-            const end = String((a as any).end ?? "").trim();
-            let cols: any = (a as any).columns;
-            if (typeof cols === "string") {
-              cols = cols
-                .split(/[,;\s]+/)
-                .map((c: string) => c.trim())
-                .filter((c: string) => c);
-            }
-            const params: { from?: string; to?: string; columns?: string[] } = {};
-            if (start) params.from = start;
-            if (end) params.to = end;
-            if (Array.isArray(cols) && cols.length) params.columns = cols;
-            if (Object.keys(params).length) {
-              this.archiveQueryDefaults.set(key, params);
-            }
-            archiveKeys.push(key);
-          } else {
-            const key = this.normalizeArchiveKey(String(a).trim());
-            if (!key) continue;
-            archiveKeys.push(key);
-          }
-        }
-      } else {
-        const arr = String(rawArchives ?? "")
-          .split(/[,;\s]+/)
-          .map((k) => k.trim())
-          .filter((k) => k)
-          .map((k) => this.normalizeArchiveKey(k));
-        archiveKeys.push(...arr);
-      }
-      for (const key of archiveKeys) {
-        if (!this.archiveDescMap.has(key)) this.archiveDescMap.set(key, key);
-      }
-      this.archiveKeys = archiveKeys;
+      this.archiveKeys = parsed.archiveKeys;
+      this.archiveDescMap = parsed.archiveDescMap;
+      this.archiveQueryDefaults = parsed.archiveQueryDefaults;
 
       for (const key of this.endpointKeys) {
         if (!this.keyDescMap.has(key)) this.keyDescMap.set(key, key);
@@ -517,11 +482,15 @@ class GiraEndpointAdapter extends utils.Adapter {
         /* ignore */
       }
 
-      const ca = cfg.ca ? String(cfg.ca) : undefined;
-      const cert = cfg.cert ? String(cfg.cert) : undefined;
-      const key = cfg.key ? String(cfg.key) : undefined;
-      const rejectUnauthorized = cfg.rejectUnauthorized !== undefined ? Boolean(cfg.rejectUnauthorized) : undefined;
-      const tls = { ca, cert, key, rejectUnauthorized };
+      const tls = {
+        ca: ca ? String(ca) : undefined,
+        cert: cert ? String(cert) : undefined,
+        key: key ? String(key) : undefined,
+        rejectUnauthorized:
+          rejectUnauthorized !== undefined
+            ? Boolean(rejectUnauthorized)
+            : undefined,
+      };
 
       // Instantiate client once with all relevant options
       this.client = new GiraClient({
@@ -534,8 +503,8 @@ class GiraEndpointAdapter extends utils.Adapter {
         authHeader,
         pingIntervalMs,
         reconnect: {
-          minMs: cfg.reconnect?.minMs ?? 1000,
-          maxMs: cfg.reconnect?.maxMs ?? 30000,
+          minMs: reconnect?.minMs ?? 1000,
+          maxMs: reconnect?.maxMs ?? 30000,
         },
         tls,
       });

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,5 +1,105 @@
 const assert = require("assert").strict;
 const { encodeUidValue, decodeCoValue } = require("../build/lib/valueConversion");
+const { parseAdapterConfig } = require("../build/lib/configParser");
+
+const parserHelpers = {
+  normalizeKey: (rawKey) => {
+    const key = String(rawKey ?? "").trim().replace(/^CO@/i, "").toUpperCase();
+    return key ? `CO@${key}` : "";
+  },
+  normalizeArchiveKey: (rawKey) => {
+    const key = String(rawKey ?? "").trim().replace(/^DA@/i, "").toUpperCase();
+    return key ? `DA@${key}` : "";
+  },
+  makeEndpointBaseId: (key) => `CO@.${String(key).replace(/^CO@/i, "")}`,
+};
+
+const parsedConnection = parseAdapterConfig(
+  { host: " 1.2.3.4 ", port: "81", ssl: true, authHeader: true },
+  parserHelpers
+);
+assert.equal(parsedConnection.connection.host, "1.2.3.4");
+assert.equal(parsedConnection.connection.port, 81);
+assert.equal(parsedConnection.connection.ssl, true);
+assert.equal(parsedConnection.connection.path, "/endpoints/ws");
+assert.equal(parsedConnection.connection.authHeader, true);
+
+const parsedArchiveString = parseAdapterConfig(
+  { dataArchives: "Archiv1 Archiv2" },
+  parserHelpers
+);
+assert.deepStrictEqual(parsedArchiveString.archiveKeys, ["DA@ARCHIV1", "DA@ARCHIV2"]);
+
+const parsedArchiveObject = parseAdapterConfig(
+  {
+    dataArchives: [
+      {
+        key: "Archiv1",
+        name: "Mein Archiv",
+        start: "2024-01-01",
+        end: "2024-01-31",
+        columns: "a b,c",
+      },
+    ],
+  },
+  parserHelpers
+);
+assert.equal(parsedArchiveObject.archiveDescMap.get("DA@ARCHIV1"), "Mein Archiv");
+assert.deepStrictEqual(parsedArchiveObject.archiveQueryDefaults.get("DA@ARCHIV1"), {
+  from: "2024-01-01",
+  to: "2024-01-31",
+  columns: ["a", "b", "c"],
+});
+
+const parsedEndpointMapping = parseAdapterConfig(
+  {
+    endpointGroups: [
+      {
+        keys: [
+          { key: "licht", textEncoding: "latin1", updateOnStart: true },
+        ],
+      },
+    ],
+    mappingGroups: [
+      {
+        mappings: [
+          {
+            stateId: "alias.0.licht",
+            key: "licht",
+            toEndpoint: true,
+            toState: true,
+            updateOnStart: true,
+            textEncoding: "latin1",
+          },
+          {
+            stateId: "alias.0.licht",
+            key: "licht",
+            toEndpoint: true,
+            updateOnStart: true,
+            textEncoding: "latin1",
+          },
+        ],
+      },
+    ],
+  },
+  parserHelpers
+);
+assert.equal(parsedEndpointMapping.keyTextEncodingMap.get("CO@LICHT"), "latin1");
+assert.deepStrictEqual(parsedEndpointMapping.forwardMap.get("alias.0.licht"), {
+  key: "CO@LICHT",
+  bool: false,
+  textEncoding: "latin1",
+});
+assert.deepStrictEqual(parsedEndpointMapping.reverseMap.get("CO@LICHT"), {
+  stateId: "alias.0.licht",
+  bool: false,
+  ack: true,
+});
+assert.equal(
+  parsedEndpointMapping.updateOnStartSources.filter((src) => src.stateId === "alias.0.licht").length,
+  1
+);
+
 
 // Cover critical text encoding conversions in the test entrypoint run by npm test.
 assert.equal(


### PR DESCRIPTION
### Motivation
- Collect all adapter config parsing in one place so connection and `dataArchives` parsing are removed from `onReady()` and reused consistently. 
- Preserve existing behavior for endpoints, mappings and archives without changing runtime logic or `GiraClient` usage. 
- Provide a single entry `parseAdapterConfig()` to simplify `onReady()` while keeping `parseEndpointAndMappingConfig()` exported for compatibility.

### Description
- Added new types and a top-level function `parseAdapterConfig(cfg, helpers): ParsedAdapterConfig` to `src/lib/configParser.ts` that returns `connection`, `archiveKeys`, `archiveDescMap`, `archiveQueryDefaults` plus the existing endpoint/mapping results. 
- Implemented `parseArchiveConfig()` inside `configParser.ts` and moved the `dataArchives` parsing logic 1:1 from `onReady()` including string/array/object handling, `enabled === false` skipping, name mapping and query-default extraction. 
- Updated `src/main.ts` `onReady()` to call `parseAdapterConfig()` and consume `parsed.connection` and parsed archive structures, leaving object creation, event handling and `GiraClient` instantiation/behavior unchanged. 
- Kept `parseEndpointAndMappingConfig()` exported and reused it internally; updated `test/main.test.js` to add node/assert parser checks for connection parsing, archive parsing and endpoint/mapping behavior.

### Testing
- Ran `npm run build` which succeeded and produced updated `build/` artifacts. 
- Ran `npm test` where the added parser assertions executed but the test run exited with failure because `@iobroker/testing` could not be resolved in this environment. 
- Executed manual node/assert checks against `build/lib/configParser.js` validating connection parsing and archive parsing which passed. 
- Confirmed no changes were made to `GiraClient` or runtime archive handlers and that `onReady()` no longer contains direct connection/archive parsing (parsing is centralized in `parseAdapterConfig`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50994ea6b88325bf0056c64063b446)