### PR TITLE
Update data archive admin config

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -451,19 +451,65 @@
               "default": true
             },
             {
-              "type": "text",
-              "attr": "start",
-              "label": "Startzeit"
+              "type": "select",
+              "attr": "mode",
+              "label": "Abfrage-Modus",
+              "default": "manual",
+              "options": [
+                {
+                  "label": "Manuell / feste Startzeit",
+                  "value": "manual"
+                },
+                {
+                  "label": "Letzte Blöcke per Button",
+                  "value": "last"
+                }
+              ],
+              "help": "manual: automatischer Abruf beim Start mit startat/cnt/size. last: Abruf über DA@.<Archiv>.last Button."
             },
             {
               "type": "text",
-              "attr": "end",
-              "label": "Endzeit"
+              "attr": "startat",
+              "label": "Startzeit (YYMMDDHHMM)",
+              "help": "Startzeit für manuelle get-Abfrage, z. B. 2607100800 = 10.07.2026 08:00"
+            },
+            {
+              "type": "number",
+              "attr": "cnt",
+              "label": "Anzahl Blöcke",
+              "min": 1,
+              "default": 50,
+              "help": "Anzahl der Datenblöcke für die manuelle Abfrage"
+            },
+            {
+              "type": "number",
+              "attr": "size",
+              "label": "Blockgröße (Minuten)",
+              "min": 1,
+              "default": 1,
+              "help": "Größe eines Datenblocks in Minuten"
             },
             {
               "type": "text",
-              "attr": "columns",
-              "label": "Spalten"
+              "attr": "cols",
+              "label": "Spalten",
+              "help": "Spalten als #Index oder Schlüssel, getrennt mit Leerzeichen/Komma/Semikolon, z. B. #1 #2 oder CREDIT DEBIT"
+            },
+            {
+              "type": "number",
+              "attr": "lastCnt",
+              "label": "Letzte Blöcke",
+              "min": 1,
+              "default": 50,
+              "help": "Anzahl der Blöcke für den Komfortabruf über DA@.<Archiv>.last"
+            },
+            {
+              "type": "number",
+              "attr": "blockSize",
+              "label": "Blockgröße letzte Abfrage (Minuten)",
+              "min": 1,
+              "default": 1,
+              "help": "Blockgröße in Minuten für den Komfortabruf über DA@.<Archiv>.last"
             }
           ]
         }


### PR DESCRIPTION
### Motivation
- Die Admin-Oberfläche soll die aktualisierte DA@-Archive-Config abbilden, ohne Runtime-Logik zu ändern.
- Alte Felder `start`/`end`/`columns` sind veraltet und müssen durch die neuen Archive-Attribute ersetzt werden.
- Nur die Admin-UI-Konfiguration (`admin/jsonConfig.json`) darf angepasst werden, alle anderen Komponenten bleiben unverändert.

### Description
- Behalte die bestehenden Felder `key`, `name` und `enabled` inklusive des DA@-Validators unverändert in `admin/jsonConfig.json`.
- Ersetze/ergänze die Datenarchive-Tabelle um die neuen Felder `mode`, `startat`, `cnt`, `size`, `cols`, `lastCnt` und `blockSize` mit den geforderten Typen, Defaults, Minima, Options und Hilfetexten.
- Entferne die prominente Anzeige der Legacy-Felder `start`, `end` und `columns` und ersetze `columns` durch `cols` (Legacy-Felder werden nicht mehr sichtbar/geführt).
- Es wurden keine Änderungen an Laufzeit-Logik, `CO@`, `GiraClient`, `configParser` oder `archiveQuery` vorgenommen; Änderung beschränkt sich auf `admin/jsonConfig.json`.

### Testing
- JSON-Syntax validiert mit `python -m json.tool admin/jsonConfig.json` and build ausgeführt mit `npm run build`, beides erfolgreich.
- `npm test` wurde ausgeführt; Testskript lief durch und exitierte erfolgreich (Integrationstests wurden übersprungen, weil `@iobroker/testing` nicht installiert ist).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50a7767040832597252ebdc3c20168)