### PR TITLE
Improve data archive last query handling

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -257,24 +257,24 @@
           "text": "Liste der Homeserver Endpunkt IDs die abonniert werden und zusätzlich in einen anderes ioBroker Objekt geschrieben / von dort gelesen werden",
           "size": 2
         },
-          "mappingGroups": {
-            "type": "accordion",
-            "label": "Hier Gruppen erstellen und die Endpunkt IDs und ioBroker Objekte eintragen",
-            "titleAttr": "group",
-            "items": [
-              {
-                "type": "text",
-                "attr": "group",
-                "label": "Gruppenname",
-                "xs": 12,
-                "sm": 12,
-                "md": 6,
-                "lg": 6,
-                "xl": 6,
-                "validator": "data.group.length > 0",
-                "validatorErrorText": "Pflichtfeld",
-                "validatorNoSaveOnError": true
-              },
+        "mappingGroups": {
+          "type": "accordion",
+          "label": "Hier Gruppen erstellen und die Endpunkt IDs und ioBroker Objekte eintragen",
+          "titleAttr": "group",
+          "items": [
+            {
+              "type": "text",
+              "attr": "group",
+              "label": "Gruppenname",
+              "xs": 12,
+              "sm": 12,
+              "md": 6,
+              "lg": 6,
+              "xl": 6,
+              "validator": "data.group.length > 0",
+              "validatorErrorText": "Pflichtfeld",
+              "validatorNoSaveOnError": true
+            },
             {
               "newLine": true,
               "type": "accordion",
@@ -423,8 +423,9 @@
           "size": 2
         },
         "dataArchives": {
-          "type": "table",
-          "label": "Hier die Datenarchiv IDs ohne das DA@ eintragen",
+          "type": "accordion",
+          "label": "Datenarchive",
+          "titleAttr": "key",
           "xs": 12,
           "sm": 12,
           "md": 12,
@@ -435,6 +436,11 @@
               "type": "text",
               "attr": "key",
               "label": "DA@",
+              "xs": 12,
+              "sm": 12,
+              "md": 4,
+              "lg": 4,
+              "xl": 4,
               "validator": "((data.key || '').trim().length > 0) && !((data.key || '').trim().toUpperCase().startsWith('DA@'))",
               "validatorErrorText": "Pflichtfeld, ohne führendes DA@",
               "validatorNoSaveOnError": true
@@ -442,74 +448,118 @@
             {
               "type": "text",
               "attr": "name",
-              "label": "Beschreibung"
+              "label": "Beschreibung",
+              "xs": 12,
+              "sm": 12,
+              "md": 5,
+              "lg": 5,
+              "xl": 5
             },
             {
               "type": "checkbox",
               "attr": "enabled",
               "label": "Aktiviert",
-              "default": true
+              "default": true,
+              "xs": 12,
+              "sm": 12,
+              "md": 3,
+              "lg": 3,
+              "xl": 3
             },
             {
+              "newLine": true,
               "type": "select",
               "attr": "mode",
-              "label": "Abfrage-Modus",
+              "label": "Modus",
               "default": "manual",
               "options": [
                 {
-                  "label": "Manuell / feste Startzeit",
+                  "label": "Manuell",
                   "value": "manual"
                 },
                 {
-                  "label": "Letzte Blöcke per Button",
+                  "label": "Letzte Blöcke",
                   "value": "last"
                 }
               ],
-              "help": "manual: automatischer Abruf beim Start mit startat/cnt/size. last: Abruf über DA@.<Archiv>.last Button."
-            },
-            {
-              "type": "text",
-              "attr": "startat",
-              "label": "Startzeit (YYMMDDHHMM)",
-              "help": "Startzeit für manuelle get-Abfrage, z. B. 2607100800 = 10.07.2026 08:00"
-            },
-            {
-              "type": "number",
-              "attr": "cnt",
-              "label": "Anzahl Blöcke",
-              "min": 1,
-              "default": 50,
-              "help": "Anzahl der Datenblöcke für die manuelle Abfrage"
-            },
-            {
-              "type": "number",
-              "attr": "size",
-              "label": "Blockgröße (Minuten)",
-              "min": 1,
-              "default": 1,
-              "help": "Größe eines Datenblocks in Minuten"
+              "help": "Manuell: Abruf beim Start mit Startzeit/Anzahl/Blockgröße. Letzte Blöcke: Abruf per Button im Objektbaum.",
+              "xs": 12,
+              "sm": 12,
+              "md": 6,
+              "lg": 6,
+              "xl": 6
             },
             {
               "type": "text",
               "attr": "cols",
               "label": "Spalten",
-              "help": "Spalten als #Index oder Schlüssel, getrennt mit Leerzeichen/Komma/Semikolon, z. B. #1 #2 oder CREDIT DEBIT"
+              "help": "#Index oder Schlüssel, z. B. #1 #2 oder endpointmap",
+              "xs": 12,
+              "sm": 12,
+              "md": 6,
+              "lg": 6,
+              "xl": 6
             },
             {
+              "newLine": true,
+              "type": "text",
+              "attr": "startat",
+              "label": "Startzeit",
+              "help": "Format YYMMDDHHMM, z. B. 2607100800 = 10.07.2026 08:00",
+              "xs": 12,
+              "sm": 12,
+              "md": 4,
+              "lg": 4,
+              "xl": 4
+            },
+            {
+              "type": "number",
+              "attr": "cnt",
+              "label": "Blöcke",
+              "min": 1,
+              "default": 50,
+              "xs": 12,
+              "sm": 12,
+              "md": 4,
+              "lg": 4,
+              "xl": 4
+            },
+            {
+              "type": "number",
+              "attr": "size",
+              "label": "Blockgröße min",
+              "min": 1,
+              "default": 1,
+              "xs": 12,
+              "sm": 12,
+              "md": 4,
+              "lg": 4,
+              "xl": 4
+            },
+            {
+              "newLine": true,
               "type": "number",
               "attr": "lastCnt",
               "label": "Letzte Blöcke",
               "min": 1,
               "default": 50,
-              "help": "Anzahl der Blöcke für den Komfortabruf über DA@.<Archiv>.last"
+              "xs": 12,
+              "sm": 12,
+              "md": 6,
+              "lg": 6,
+              "xl": 6
             },
             {
               "type": "number",
               "attr": "blockSize",
-              "label": "Blockgröße letzte Abfrage (Minuten)",
+              "label": "Blockgröße min",
               "min": 1,
               "default": 1,
-              "help": "Blockgröße in Minuten für den Komfortabruf über DA@.<Archiv>.last"
+              "xs": 12,
+              "sm": 12,
+              "md": 6,
+              "lg": 6,
+              "xl": 6
             }
           ]
         }

--- a/build/main.js
+++ b/build/main.js
@@ -333,6 +333,16 @@ class GiraEndpointAdapter extends utils.Adapter {
                     },
                     native: {},
                 });
+                await this.extendObjectAsync(`${baseId}.last`, {
+                    common: {
+                        name: this.translate("Daten holen"),
+                        type: "boolean",
+                        role: "button",
+                        read: true,
+                        write: true,
+                        def: false,
+                    },
+                });
                 await this.setObjectNotExistsAsync(`${baseId}.lastCnt`, {
                     type: "state",
                     common: {

--- a/build/main.js
+++ b/build/main.js
@@ -324,7 +324,7 @@ class GiraEndpointAdapter extends utils.Adapter {
                 await this.setObjectNotExistsAsync(`${baseId}.last`, {
                     type: "state",
                     common: {
-                        name: this.translate("last"),
+                        name: this.translate("Daten holen"),
                         type: "boolean",
                         role: "button",
                         read: true,
@@ -1158,6 +1158,14 @@ class GiraEndpointAdapter extends utils.Adapter {
         }
         return (0, archiveQuery_1.normalizeArchiveCols)(state?.val) ?? fallback;
     }
+    getMetaCols(metaResp) {
+        const cols = metaResp?.data?.cols;
+        if (!Array.isArray(cols))
+            return [];
+        return cols
+            .map((col) => String(col?.key ?? "").trim())
+            .filter(Boolean);
+    }
     async handleLastArchiveQuery(key, baseId, id) {
         try {
             await this.setStateAsync(id, { val: false, ack: true });
@@ -1170,16 +1178,18 @@ class GiraEndpointAdapter extends utils.Adapter {
             const lastCnt = await this.readNumberState(`${baseId}.lastCnt`, defaults?.lastCnt ?? 50);
             const blockSize = await this.readNumberState(`${baseId}.blockSize`, defaults?.blockSize ?? defaults?.size ?? 1);
             const cols = await this.readColsState(`${baseId}.cols`, defaults?.cols ?? []);
-            const queryParams = (0, archiveQuery_1.buildLastArchiveQuery)(metaResp, lastCnt, blockSize, cols);
+            const queryCols = cols.length ? cols : this.getMetaCols(metaResp);
+            const queryParams = (0, archiveQuery_1.buildLastArchiveQuery)(metaResp, lastCnt, blockSize, queryCols);
             if (!queryParams) {
                 this.log.warn(this.translate("Cannot build last archive query for %s because meta.stat.last is missing", key));
                 return;
             }
+            await this.setStateAsync(`${baseId}.query`, { val: JSON.stringify(queryParams), ack: true });
+            this.log.debug(this.translate("Fetching archive data for %s with query %s", key, JSON.stringify(queryParams)));
             const resp = await this.client.call(key, "get", queryParams, this.makeTag("get"));
             const data = JSON.stringify(resp.data);
             await this.setStateAsync(`${baseId}.data`, { val: data, ack: true });
             await this.setStateAsync(`${baseId}.lastResult`, { val: data, ack: true });
-            await this.setStateAsync(`${baseId}.query`, { val: JSON.stringify(queryParams), ack: true });
         }
         catch (err) {
             this.log.error(this.translate("Last archive query failed for %s: %s", key, err?.message || err));

--- a/src/main.ts
+++ b/src/main.ts
@@ -433,7 +433,7 @@ class GiraEndpointAdapter extends utils.Adapter {
         await this.setObjectNotExistsAsync(`${baseId}.last`, {
           type: "state",
           common: {
-            name: this.translate("last"),
+            name: this.translate("Daten holen"),
             type: "boolean",
             role: "button",
             read: true,
@@ -1396,6 +1396,14 @@ class GiraEndpointAdapter extends utils.Adapter {
     return normalizeArchiveCols(state?.val) ?? fallback;
   }
 
+  private getMetaCols(metaResp: any): string[] {
+    const cols = metaResp?.data?.cols;
+    if (!Array.isArray(cols)) return [];
+    return cols
+      .map((col) => String(col?.key ?? "").trim())
+      .filter(Boolean);
+  }
+
   private async handleLastArchiveQuery(key: string, baseId: string, id: string): Promise<void> {
     try {
       await this.setStateAsync(id, { val: false, ack: true });
@@ -1408,16 +1416,24 @@ class GiraEndpointAdapter extends utils.Adapter {
       const lastCnt = await this.readNumberState(`${baseId}.lastCnt`, defaults?.lastCnt ?? 50);
       const blockSize = await this.readNumberState(`${baseId}.blockSize`, defaults?.blockSize ?? defaults?.size ?? 1);
       const cols = await this.readColsState(`${baseId}.cols`, defaults?.cols ?? []);
-      const queryParams = buildLastArchiveQuery(metaResp, lastCnt, blockSize, cols);
+      const queryCols = cols.length ? cols : this.getMetaCols(metaResp);
+      const queryParams = buildLastArchiveQuery(metaResp, lastCnt, blockSize, queryCols);
       if (!queryParams) {
         this.log.warn(this.translate("Cannot build last archive query for %s because meta.stat.last is missing", key));
         return;
       }
+      await this.setStateAsync(`${baseId}.query`, { val: JSON.stringify(queryParams), ack: true });
+      this.log.debug(
+        this.translate(
+          "Fetching archive data for %s with query %s",
+          key,
+          JSON.stringify(queryParams)
+        )
+      );
       const resp = await this.client!.call(key, "get", queryParams, this.makeTag("get"));
       const data = JSON.stringify(resp.data);
       await this.setStateAsync(`${baseId}.data`, { val: data, ack: true });
       await this.setStateAsync(`${baseId}.lastResult`, { val: data, ack: true });
-      await this.setStateAsync(`${baseId}.query`, { val: JSON.stringify(queryParams), ack: true });
     } catch (err: any) {
       this.log.error(this.translate("Last archive query failed for %s: %s", key, err?.message || err));
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -442,6 +442,16 @@ class GiraEndpointAdapter extends utils.Adapter {
           },
           native: {},
         });
+        await this.extendObjectAsync(`${baseId}.last`, {
+          common: {
+            name: this.translate("Daten holen"),
+            type: "boolean",
+            role: "button",
+            read: true,
+            write: true,
+            def: false,
+          },
+        });
         await this.setObjectNotExistsAsync(`${baseId}.lastCnt`, {
           type: "state",
           common: {


### PR DESCRIPTION
### Motivation
- Die Bedienung der Datenarchive soll für Nutzer klarer und die Admin-UI besser lesbar sein, ohne Änderungen an CO@, GiraClient oder Mapping vorzunehmen.
- Bei der Komfort-Abfrage `DA@.<id>.last` soll die berechnete Query sichtbar bleiben, auch wenn der anschließende `get`-Aufruf fehlschlägt.

### Description
- Ändert das Label des States `DA@.<id>.last` von `this.translate("last")` auf `this.translate("Daten holen")` während ID, Typ (`boolean`), Rolle (`button`) und Rechte unverändert bleiben (Änderung in `src/main.ts`).
- Leitet fehlende `cols` für die Last-Abfrage aus `metaResp.data.cols` ab (neue Hilfsfunktion `getMetaCols` in `src/main.ts`) und nutzt diese nur zur Query-Erzeugung ohne den `cols`-State automatisch zu überschreiben.
- Baut die Query vor dem `get`-Aufruf und schreibt sie sofort in den State mit `await this.setStateAsync(`${baseId}.query`, { val: JSON.stringify(queryParams), ack: true })` (Änderung in `handleLastArchiveQuery`).
- Fügt ein Debug-Log vor dem `get` hinzu: `this.log.debug(this.translate("Fetching archive data for %s with query %s", key, JSON.stringify(queryParams)))`.
- Wurde das Admin-Formular `dataArchives` von `type: "table"` auf ein `accordion` umgestellt und Felder/Labels/Help-Texte gekürzt und responsive Breiten (`xs`/`md`/...) zugewiesen, damit die Archiv-Einträge in der Admin-UI lesbarer sind (Änderung in `admin/jsonConfig.json`).

### Testing
- `npm run build` wurde ausgeführt und der TypeScript-Build lief erfolgreich.
- `npm test` wurde ausgeführt und die ioBroker-Integrationstests wurden übersprungen mit der Meldung: `Skipping ioBroker integration tests because @iobroker/testing is not installed`.
- Ergebnisziel manuell überprüfbar: Admin UI zeigt `Daten holen` als Beschriftung von `DA@.<id>.last`, `DA@.<id>.query` wird vor `get` geschrieben, und bei leeren `cols` werden Spalten aus `metaResp.data.cols` für die Query verwendet.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50acae68588325b0f9e1fc31d18ef1)