### PR TITLE
Fix Gira request matching for minimal HomeServer responses

### DIFF
--- a/build/lib/GiraClient.js
+++ b/build/lib/GiraClient.js
@@ -8,6 +8,7 @@ exports.codeToMessage = codeToMessage;
 exports.formatCallError = formatCallError;
 const events_1 = require("events");
 const ws_1 = __importDefault(require("ws"));
+const requestMatching_1 = require("./requestMatching");
 // Kein Listener-Limit (verhindert MaxListeners-Warnungen global hier)
 events_1.EventEmitter.defaultMaxListeners = 0;
 const BACKOFF_FACTOR = 1.7;
@@ -77,6 +78,7 @@ class GiraClient extends events_1.EventEmitter {
         this.awaitingPong = false;
         this.tagResolvers = new Map();
         this.requestTags = new Map();
+        this.tagRequestKeys = new Map();
         // Defaults + Merge ohne doppelte Literal-Keys (TS2783 vermeiden)
         const defaults = {
             host: "",
@@ -160,21 +162,17 @@ class GiraClient extends events_1.EventEmitter {
                             clearTimeout(resolver.timer);
                         resolver?.reject(err);
                         this.tagResolvers.delete(tag);
-                        if (payload?.request) {
-                            const reqKey = this.makeRequestKey(payload.request);
-                            this.requestTags.delete(reqKey);
-                        }
+                        this.clearRequestTag(tag, ...(0, requestMatching_1.makeRequestKeys)(payload?.request));
                     }
                     else if (payload?.request) {
-                        const reqKey = this.makeRequestKey(payload.request);
-                        const t = this.requestTags.get(reqKey);
+                        const { tag: t, requestKeys } = this.findRequestTag(payload.request);
                         if (t && this.tagResolvers.has(t)) {
                             const resolver = this.tagResolvers.get(t);
                             if (resolver?.timer)
                                 clearTimeout(resolver.timer);
                             resolver?.reject(err);
                             this.tagResolvers.delete(t);
-                            this.requestTags.delete(reqKey);
+                            this.clearRequestTag(t, ...requestKeys);
                         }
                     }
                     this.emit("error", err);
@@ -189,21 +187,17 @@ class GiraClient extends events_1.EventEmitter {
                         clearTimeout(resolver.timer);
                     resolver?.resolve(payload);
                     this.tagResolvers.delete(tag);
-                    if (payload?.request) {
-                        const reqKey = this.makeRequestKey(payload.request);
-                        this.requestTags.delete(reqKey);
-                    }
+                    this.clearRequestTag(tag, ...(0, requestMatching_1.makeRequestKeys)(payload?.request));
                 }
                 else if (payload?.request) {
-                    const reqKey = this.makeRequestKey(payload.request);
-                    const t = this.requestTags.get(reqKey);
+                    const { tag: t, requestKeys } = this.findRequestTag(payload.request);
                     if (t && this.tagResolvers.has(t)) {
                         const resolver = this.tagResolvers.get(t);
                         if (resolver?.timer)
                             clearTimeout(resolver.timer);
                         resolver?.resolve(payload);
                         this.tagResolvers.delete(t);
-                        this.requestTags.delete(reqKey);
+                        this.clearRequestTag(t, ...requestKeys);
                     }
                 }
             }
@@ -229,13 +223,23 @@ class GiraClient extends events_1.EventEmitter {
         }
     }
     makeRequestKey(obj) {
-        if (!obj || typeof obj !== "object")
-            return String(obj);
-        const keys = Object.keys(obj).sort();
-        const sorted = {};
-        for (const k of keys)
-            sorted[k] = obj[k];
-        return JSON.stringify(sorted);
+        return (0, requestMatching_1.makeRequestKey)(obj);
+    }
+    clearRequestTag(tag, ...requestKeys) {
+        const knownRequestKeys = this.tagRequestKeys.get(tag) ?? [];
+        const keys = new Set([...knownRequestKeys, ...requestKeys]);
+        for (const requestKey of keys)
+            this.requestTags.delete(requestKey);
+        this.tagRequestKeys.delete(tag);
+    }
+    findRequestTag(request) {
+        const requestKeys = (0, requestMatching_1.makeRequestKeys)(request);
+        for (const requestKey of requestKeys) {
+            const tag = this.requestTags.get(requestKey);
+            if (tag)
+                return { tag, requestKeys };
+        }
+        return { requestKeys };
     }
     call(key, method, params, tag, timeoutMs = 10000) {
         const param = { key, method };
@@ -250,15 +254,17 @@ class GiraClient extends events_1.EventEmitter {
         const msg = { type: "call", param };
         if (tag) {
             msg.tag = tag;
-            const reqKey = this.makeRequestKey(param);
+            const requestKeys = (0, requestMatching_1.makeRequestKeys)(param);
             return new Promise((resolve, reject) => {
                 const timer = setTimeout(() => {
                     reject(new Error(`Gira call failed: Timeout, key=${key}, method=${method}, tag=${tag}, params=${shorten(safeStringify(param) ?? String(param))}`));
                     this.tagResolvers.delete(tag);
-                    this.requestTags.delete(reqKey);
+                    this.clearRequestTag(tag, ...requestKeys);
                 }, timeoutMs);
                 this.tagResolvers.set(tag, { resolve, reject, timer });
-                this.requestTags.set(reqKey, tag);
+                this.tagRequestKeys.set(tag, requestKeys);
+                for (const requestKey of requestKeys)
+                    this.requestTags.set(requestKey, tag);
                 this.send(msg);
             });
         }

--- a/build/lib/requestMatching.js
+++ b/build/lib/requestMatching.js
@@ -1,0 +1,31 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.makeRequestKey = makeRequestKey;
+exports.makeMinimalRequest = makeMinimalRequest;
+exports.makeRequestKeys = makeRequestKeys;
+function makeRequestKey(obj) {
+    if (!obj || typeof obj !== "object")
+        return String(obj);
+    const keys = Object.keys(obj).sort();
+    const sorted = {};
+    for (const k of keys)
+        sorted[k] = obj[k];
+    return JSON.stringify(sorted);
+}
+function makeMinimalRequest(value) {
+    const key = value?.key;
+    const method = value?.method;
+    if (key === undefined || method === undefined)
+        return undefined;
+    return { key, method };
+}
+function makeRequestKeys(value) {
+    const keys = [makeRequestKey(value)];
+    const minimalRequest = makeMinimalRequest(value);
+    if (minimalRequest) {
+        const minimalKey = makeRequestKey(minimalRequest);
+        if (!keys.includes(minimalKey))
+            keys.push(minimalKey);
+    }
+    return keys;
+}

--- a/src/lib/GiraClient.ts
+++ b/src/lib/GiraClient.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "events";
 import WebSocket from "ws";
+import { makeRequestKey, makeRequestKeys } from "./requestMatching";
 
 // Kein Listener-Limit (verhindert MaxListeners-Warnungen global hier)
 EventEmitter.defaultMaxListeners = 0;
@@ -114,6 +115,7 @@ export class GiraClient extends EventEmitter {
     }
   >();
   private requestTags = new Map<string, string>();
+  private tagRequestKeys = new Map<string, string[]>();
 
   constructor(opts: GiraClientOptions) {
     super();
@@ -206,19 +208,15 @@ export class GiraClient extends EventEmitter {
             if (resolver?.timer) clearTimeout(resolver.timer as any);
             resolver?.reject(err);
             this.tagResolvers.delete(tag);
-            if (payload?.request) {
-              const reqKey = this.makeRequestKey(payload.request);
-              this.requestTags.delete(reqKey);
-            }
+            this.clearRequestTag(tag, ...makeRequestKeys(payload?.request));
           } else if (payload?.request) {
-            const reqKey = this.makeRequestKey(payload.request);
-            const t = this.requestTags.get(reqKey);
+            const { tag: t, requestKeys } = this.findRequestTag(payload.request);
             if (t && this.tagResolvers.has(t)) {
               const resolver = this.tagResolvers.get(t);
               if (resolver?.timer) clearTimeout(resolver.timer as any);
               resolver?.reject(err);
               this.tagResolvers.delete(t);
-              this.requestTags.delete(reqKey);
+              this.clearRequestTag(t, ...requestKeys);
             }
           }
           this.emit("error", err);
@@ -232,19 +230,15 @@ export class GiraClient extends EventEmitter {
           if (resolver?.timer) clearTimeout(resolver.timer as any);
           resolver?.resolve(payload);
           this.tagResolvers.delete(tag);
-          if (payload?.request) {
-            const reqKey = this.makeRequestKey(payload.request);
-            this.requestTags.delete(reqKey);
-          }
+          this.clearRequestTag(tag, ...makeRequestKeys(payload?.request));
         } else if (payload?.request) {
-          const reqKey = this.makeRequestKey(payload.request);
-          const t = this.requestTags.get(reqKey);
+          const { tag: t, requestKeys } = this.findRequestTag(payload.request);
           if (t && this.tagResolvers.has(t)) {
             const resolver = this.tagResolvers.get(t);
             if (resolver?.timer) clearTimeout(resolver.timer as any);
             resolver?.resolve(payload);
             this.tagResolvers.delete(t);
-            this.requestTags.delete(reqKey);
+            this.clearRequestTag(t, ...requestKeys);
           }
         }
       } catch (err) {
@@ -272,11 +266,23 @@ export class GiraClient extends EventEmitter {
   }
 
   private makeRequestKey(obj: any): string {
-    if (!obj || typeof obj !== "object") return String(obj);
-    const keys = Object.keys(obj).sort();
-    const sorted: any = {};
-    for (const k of keys) sorted[k] = obj[k];
-    return JSON.stringify(sorted);
+    return makeRequestKey(obj);
+  }
+
+  private clearRequestTag(tag: string, ...requestKeys: string[]): void {
+    const knownRequestKeys = this.tagRequestKeys.get(tag) ?? [];
+    const keys = new Set([...knownRequestKeys, ...requestKeys]);
+    for (const requestKey of keys) this.requestTags.delete(requestKey);
+    this.tagRequestKeys.delete(tag);
+  }
+
+  private findRequestTag(request: any): { tag?: string; requestKeys: string[] } {
+    const requestKeys = makeRequestKeys(request);
+    for (const requestKey of requestKeys) {
+      const tag = this.requestTags.get(requestKey);
+      if (tag) return { tag, requestKeys };
+    }
+    return { requestKeys };
   }
 
   public call(
@@ -297,15 +303,16 @@ export class GiraClient extends EventEmitter {
     const msg: any = { type: "call", param };
     if (tag) {
       msg.tag = tag;
-      const reqKey = this.makeRequestKey(param);
+      const requestKeys = makeRequestKeys(param);
       return new Promise((resolve, reject) => {
         const timer = setTimeout(() => {
           reject(new Error(`Gira call failed: Timeout, key=${key}, method=${method}, tag=${tag}, params=${shorten(safeStringify(param) ?? String(param))}`));
           this.tagResolvers.delete(tag);
-          this.requestTags.delete(reqKey);
+          this.clearRequestTag(tag, ...requestKeys);
         }, timeoutMs);
         this.tagResolvers.set(tag, { resolve, reject, timer });
-        this.requestTags.set(reqKey, tag);
+        this.tagRequestKeys.set(tag, requestKeys);
+        for (const requestKey of requestKeys) this.requestTags.set(requestKey, tag);
         this.send(msg);
       });
     }

--- a/src/lib/requestMatching.ts
+++ b/src/lib/requestMatching.ts
@@ -1,0 +1,24 @@
+export function makeRequestKey(obj: any): string {
+  if (!obj || typeof obj !== "object") return String(obj);
+  const keys = Object.keys(obj).sort();
+  const sorted: any = {};
+  for (const k of keys) sorted[k] = obj[k];
+  return JSON.stringify(sorted);
+}
+
+export function makeMinimalRequest(value: any): any | undefined {
+  const key = value?.key;
+  const method = value?.method;
+  if (key === undefined || method === undefined) return undefined;
+  return { key, method };
+}
+
+export function makeRequestKeys(value: any): string[] {
+  const keys = [makeRequestKey(value)];
+  const minimalRequest = makeMinimalRequest(value);
+  if (minimalRequest) {
+    const minimalKey = makeRequestKey(minimalRequest);
+    if (!keys.includes(minimalKey)) keys.push(minimalKey);
+  }
+  return keys;
+}

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -2,6 +2,35 @@ const assert = require("assert").strict;
 const { encodeUidValue, decodeCoValue } = require("../build/lib/valueConversion");
 const { parseAdapterConfig } = require("../build/lib/configParser");
 const { normalizeArchiveQuery, isExecutableArchiveQuery, buildLastArchiveQuery, formatArchiveStartAt } = require("../build/lib/archiveQuery");
+const { makeMinimalRequest, makeRequestKey, makeRequestKeys } = require("../build/lib/requestMatching");
+
+
+const fullArchiveRequest = {
+  key: "DA@ENDPOINT",
+  method: "get",
+  startat: "2607080701",
+  cnt: 50,
+  size: 60,
+  cols: ["#1"],
+};
+const minimalArchiveRequest = { key: "DA@ENDPOINT", method: "get" };
+const fullArchiveRequestKey = makeRequestKey(fullArchiveRequest);
+const minimalArchiveRequestKey = makeRequestKey(minimalArchiveRequest);
+assert.deepStrictEqual(makeMinimalRequest(fullArchiveRequest), minimalArchiveRequest);
+assert.deepStrictEqual(makeRequestKeys(fullArchiveRequest), [
+  fullArchiveRequestKey,
+  minimalArchiveRequestKey,
+]);
+
+const requestTagMap = new Map();
+const tag = "archive-tag";
+for (const requestKey of makeRequestKeys(fullArchiveRequest)) requestTagMap.set(requestKey, tag);
+assert.equal(requestTagMap.get(fullArchiveRequestKey), tag);
+assert.equal(requestTagMap.get(minimalArchiveRequestKey), tag);
+assert.equal(requestTagMap.get(makeRequestKey(minimalArchiveRequest)), tag);
+for (const requestKey of makeRequestKeys(fullArchiveRequest)) requestTagMap.delete(requestKey);
+assert.equal(requestTagMap.has(fullArchiveRequestKey), false);
+assert.equal(requestTagMap.has(minimalArchiveRequestKey), false);
 
 const parserHelpers = {
   normalizeKey: (rawKey) => {


### PR DESCRIPTION
### Motivation
- DA@ `get` responses from some HomeServers include only `{ key, method }` in `request`, while the adapter previously stored a full request key including query params, causing `client.call(...).then` to time out because the response didn't match the stored request key.

### Description
- Add pure helpers in `src/lib/requestMatching.ts`: `makeRequestKey`, `makeMinimalRequest`, and `makeRequestKeys` to produce stable full and minimal request keys.
- Update `GiraClient` to store both full and minimal request keys per tag, introduce `tagRequestKeys`, and add `clearRequestTag` and `findRequestTag` helpers for robust cleanup and lookup.
- Change WebSocket message handling to match incoming success and error payloads against both full and minimal request keys and to remove both keys on resolve/reject/timeout.
- Add unit assertions in `test/main.test.js` that cover full/minimal key generation, mapping and cleanup behavior.

### Testing
- Ran `npm run build` and TypeScript compilation completed successfully.
- Ran `npm test` and the unit tests passed; integration tests were automatically skipped because the optional `@iobroker/testing` harness is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50b332ca90832590497a09bae76372)