### PR TITLE
Release 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ Wenn er dir gefällt oder dir weiterhilft, freue ich mich über eine kleine Spen
 
 ## Changelog
 
+### 0.4.0
+* Add Latin1/UTF-8 text encoding for CO@ texts and decode incoming CO@ text values
+* Improve Gira call error diagnostics and debug logs
+* Centralize config parsing
+* Repair DA@ data archives for startat/cnt/size/cols and add "Daten holen" last-block queries
+* Update DA@ admin UI to an accordion and fix request matching for reduced HomeServer responses
+
 ### 0.3.1
 * Add `info.hsRestart` trigger to resend all \"update on start\" states after a HomeServer restart
 

--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,12 @@
 {
   "common": {
     "name": "gira-endpoint",
-    "version": "0.3.3",
+    "version": "0.4.0",
     "news": {
+      "0.4.0": {
+        "en": "Add and improve DA@ data archive support with Gira get parameters, last-block queries, admin UI updates, and robust request matching",
+        "de": "DA@ Datenarchive ergänzt und verbessert: korrekte Gira-get-Parameter, Letzte-Blöcke-Abfrage, aktualisierte Admin-UI und robustes Request-Matching"
+      },
       "0.3.3": {
         "en": "Improve admin config validation, value conversion structure, and Gira call diagnostics",
         "de": "Verbessert Admin-Konfig-Validierung, Werte-Konvertierung und Diagnose von Gira-Aufrufen"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.gira-endpoint",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@iobroker/adapter-core": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.gira-endpoint",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "ioBroker adapter for Gira endpoint (WS/WSS) – emits events as states, minimal viable replacement for Node-RED Gira node",
   "author": "you",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
### Motivation
- Prepare a release by bumping the adapter version to `0.4.0` and adding release notes for the new version. 
- Keep runtime logic unchanged and only modify metadata, changelog/news and release-preparation artifacts. 

### Description
- Bumped version to `0.4.0` in `package.json` and `io-package.json` and synchronized root versions in `package-lock.json`.
- Added a new top `common.news` entry for `0.4.0` in `io-package.json` with English and German texts describing DA@ archive improvements and request-matching fixes. 
- Inserted a short `0.4.0` entry in the `README.md` changelog summarizing CO@ encoding/decoding, Gira diagnostics, config parsing centralization, DA@ fixes, admin UI and request-matching fixes. 
- Changes were committed on branch `work` with commit message `Release 0.4.0` and a release PR titled `Release 0.4.0` was created targeting `main`.

### Testing
- Ran `npm install --package-lock-only` which failed due to registry access (`403 Forbidden` for `@iobroker/testing`), however the lockfile root versions were updated in the repo. 
- Ran `npm run build` which completed successfully. 
- Ran `npm test` which completed; ioBroker integration tests were skipped because `@iobroker/testing` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50bbdd1ddc8325a9d96c7c79ca08ad)